### PR TITLE
Add Helm Repo web page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+theme: jekyll-theme-slate
+name: CrowdStrike Falcon Helm Chart
+description: Helm charts for running CrowdStrike Falcon with Kubernetes
+plugins:
+  - jekyll-seo-tag

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="icon" href="https://www.crowdstrike.com/wp-content/uploads/2018/09/favicon-96x96.png" type="image/png" sizes="16x16">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+{% seo %}
+  </head>
+
+  <body>
+
+    <!-- HEADER -->
+    <div id="header_wrap" class="outer">
+        <header class="inner">
+	  <p align="center">
+	  <a href="https://crowdstrike.com"><img src="https://www.crowdstrike.com/wp-content/uploads/2018/09/favicon-96x96.png" alt="logo" /></a>
+          </p>
+          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+
+          {% if site.show_downloads %}
+            <section id="downloads">
+              <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
+              <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
+            </section>
+          {% endif %}
+        </header>
+    </div>
+
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap" class="outer">
+      <section id="main_content" class="inner">
+        {{ content }}
+      </section>
+    </div>
+
+    <!-- FOOTER  -->
+    <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        {% if site.github.is_project_page %}
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div>
+
+    {% if site.google_analytics %}
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{ site.google_analytics }}', 'auto');
+        ga('send', 'pageview');
+      </script>
+    {% endif %}
+  </body>
+</html>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,29 @@
+# CrowdStrike Falcon Helm Repository
+
+<br><br>
+### Add the CrowdStrike Falcon Helm repository
+
+```
+helm repo add crowdstrike https://crowdstrike.github.io/falcon-helm
+```
+
+<br>
+### Install CrowdStrike Falcon Helm Chart
+
+```
+helm upgrade --install falcon-helm crowdstrike/falcon-sensor \
+    --set falcon.cid="<CrowdStrike_CID>" \
+    --set node.image.repository="<Your_Registry>/falcon-node-sensor"
+```
+
+Above command will install the CrowdStrike Falcon Helm Chart with the release name `falcon-helm` in the namespace your `kubectl` context is currently set to.
+You can install also install into a customized namespace by running the following:
+
+```
+helm upgrade --install falcon-helm crowdstrike/falcon-sensor \
+    -n falcon-system --create-namespace \
+    --set falcon.cid="<CrowdStrike_CID>" \
+    --set node.image.repository="<Your_Registry>/falcon-node-sensor"
+``` 
+
+For more details please see the [falcon-helm](https://github.com/CrowdStrike/falcon-helm) repository.


### PR DESCRIPTION
We can now host our own helm repo in github and use our releases as the artifacts rather than storing a helm chart archive in a repo