### PR TITLE
Don't use /tmp to store falcon information

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.6.0
+appVersion: 0.7.0
 
 
 keywords:

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -62,10 +62,10 @@ spec:
       # restarts.
       - name: init-falconstore
         image: busybox
-        args: [/bin/sh, -c, 'touch /tmp/CrowdStrike/falconstore']
+        args: [/bin/sh, -c, 'touch /var/lib/crowdstrike/falconstore']
         volumeMounts:
           - name: falconstore-dir
-            mountPath: /tmp/CrowdStrike
+            mountPath: /var/lib/crowdstrike
       containers:
       - name: falcon-node-sensor
         image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"
@@ -119,10 +119,10 @@ spec:
           emptyDir: {}
         - name: falconstore
           hostPath:
-            path: /tmp/CrowdStrike/falconstore
+            path: /var/lib/crowdstrike/falconstore
         - name: falconstore-dir
           hostPath:
-            path: /tmp/CrowdStrike
+            path: /var/lib/crowdstrike
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Using the tmp directory means that the system can wipe out falcon information. This PR also updates the falconstore to be located where Linux would typically expect application data to be stored.