### PR TITLE
Add support for setting serviceAccountName

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.904
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -130,6 +130,9 @@ spec:
         - name: falconstore-dir
           hostPath:
             path: /var/lib/crowdstrike
+      {{- if .Values.node.daemonset.serviceAccountName }}
+      serviceAccountName: {{ .Values.node.daemonset.serviceAccountName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
       hostNetwork: true
       hostPID: true

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -38,6 +38,9 @@
                         "updateStrategy": {
                             "type": "string",
                             "default": "RollingUpdate"
+                        },
+                        "serviceAccountName": {
+                            "type": "string"
                         }
                     }
                 },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -18,6 +18,8 @@ node:
 
     updateStrategy: RollingUpdate
 
+    serviceAccountName: ""
+
   image:
     repository: falcon-node-sensor
     pullPolicy: Always


### PR DESCRIPTION
Setting `serviceAccountName` is necessary when using PodSecurityPolicies that generally don't allow running privileged pods. In this case, a separate service account must be created and associated with a privileged PodSecurityPolicy.

This adds a small template change to allow setting this value from `.Vaules.node.daemonset.serviceAccountName`.