### PR TITLE
Kubernetes 1.22 should be supported

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.3.0
+appVersion: 1.3.1
 
 
 keywords:
@@ -42,4 +42,4 @@ maintainers:
     email: integrations@crowdstrike.com
 
 icon: https://raw.githubusercontent.com/CrowdStrike/falcon-helm/main/images/crowdstrike-logo.svg
-kubeVersion: ">1.15.0-0 <1.22.0-0"
+kubeVersion: ">1.15.0-0 <1.23.0-0"


### PR DESCRIPTION
Addressing 
```
Error: chart requires kubeVersion: >1.15.0-0 <1.22.0-0 which is incompatible with Kubernetes v1.22.1-3+e6976ed80e19e1
```