### PR TITLE
Force injector to be restarted after deployment

### DIFF
--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -33,6 +33,8 @@ spec:
       crowdstrike.com/provider: crowdstrike
   template:
     metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: {{ include "falcon-sensor.name" . }}-injector
         app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}


### PR DESCRIPTION
Adding this fix to restart the injector automatically, when the helm chart is played again (adding new namespaces, changing sensor params like tags...)
without this fix, secret TLS certificate is changed but process not restarted so you may have these logs :
http: TLS handshake error from 10.244.0.4:34902: remote error: tls: bad certificate
http: TLS handshake error from 10.244.0.4:34902: remote error: tls: bad certificate

and a delay for Kubernetes to deploy/redeploy new pod (as K8s is waiting an answer for the mutating webhook).