### PR TITLE
Move CID to Secret Object

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.6.0
+appVersion: 1.7.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/README.md
+++ b/helm-charts/falcon-sensor/README.md
@@ -41,19 +41,24 @@ helm repo update
 
 The following tables lists the Falcon Sensor configurable parameters and their default values.
 
-| Parameter                   | Description                                          | Default                   |
-|:----------------------------|:-----------------------------------------------------|:------------------------- |
-| `falcon.cid`                | CrowdStrike Customer ID (CID)                        | None       (Required)     |
-| `falcon.apd`                | Enable/Disable the Proxy.                            | None                      |
-| `falcon.aph`                | App Proxy Hostname (APH)                             | None                      |
-| `falcon.app`                | App Proxy Port (APP)                                 | None                      |
-| `falcon.trace`              | Set trace level                                      | `none`                    |
-| `falcon.feature`            | Sensor Feature options                               | None                      |
-| `falcon.message_log`        | Enable message log (true/false)                      | None                      |
-| `falcon.billing`            | Utilize default or metered billing                   | None                      |
-| `falcon.tags`               | Comma separated list of tags for sensor grouping     | None                      |
-| `falcon.provisioning_token` | Provisioning token value                             | None                      |
+| Parameter                   | Description                                      | Default |
+| :-------------------------- | :----------------------------------------------- | :------ |
+| `falcon.cid`                | CrowdStrike Customer ID (CID)                    | None    |
+| `falcon.apd`                | Enable/Disable the Proxy.                        | None    |
+| `falcon.aph`                | App Proxy Hostname (APH)                         | None    |
+| `falcon.app`                | App Proxy Port (APP)                             | None    |
+| `falcon.trace`              | Set trace level                                  | `none`  |
+| `falcon.feature`            | Sensor Feature options                           | None    |
+| `falcon.message_log`        | Enable message log (true/false)                  | None    |
+| `falcon.billing`            | Utilize default or metered billing               | None    |
+| `falcon.tags`               | Comma separated list of tags for sensor grouping | None    |
+| `falcon.provisioning_token` | Provisioning token value                         | None    |
 
+## Setting the Falcon Sensor CID
+
+You may configure the Falcon sensor's Customer ID by setting the `falcon.cid` value, or by creating your own Kubernetes secret object and referencing its name using the `existingSecretName` value. The secret object must contain the key `FALCONCTL_OPT_CID`.
+
+`falcon.cid` and `existingSecretName` are mutually exclusive.
 
 ## Installing on Kubernetes Cluster Nodes
 
@@ -93,16 +98,16 @@ For more details please see the [falcon-helm](https://github.com/CrowdStrike/fal
 
 The following tables lists the more common configurable parameters of the chart and their default values for installing on a Kubernetes node.
 
-| Parameter                       | Description                                                          | Default                                   |
-|:--------------------------------|:---------------------------------------------------------------------|:----------------------------------------- |
-| `node.enabled`                  | Enable installation on the Kubernetes node                           | `true`                                    |
-| `node.image.repository`         | Falcon Sensor Node registry/image name                               | `falcon-node-sensor`                      |
-| `node.image.tag`                | The version of the official image to use                             | `latest`                                  |
-| `node.image.pullPolicy`         | Policy for updating images                                           | `Always`                                  |
-| `node.image.pullSecrets`        | Pull secrets for private registry                                    | `{}`                                      |
-| `falcon.cid`                    | CrowdStrike Customer ID (CID)                                        | None       (Required)                     |
+| Parameter                | Description                                | Default              |
+| :----------------------- | :----------------------------------------- | :------------------- |
+| `node.enabled`           | Enable installation on the Kubernetes node | `true`               |
+| `node.image.repository`  | Falcon Sensor Node registry/image name     | `falcon-node-sensor` |
+| `node.image.tag`         | The version of the official image to use   | `latest`             |
+| `node.image.pullPolicy`  | Policy for updating images                 | `Always`             |
+| `node.image.pullSecrets` | Pull secrets for private registry          | `{}`                 |
+| `falcon.cid`             | CrowdStrike Customer ID (CID)              | None                 |
 
-`falcon.cid` and `node.image.repository` are required values.
+`node.image.repository` is a required value.
 
 ## Installing in Kubernetes Cluster as a Sidecar
 
@@ -140,21 +145,21 @@ helm upgrade --install falcon-helm crowdstrike/falcon-sensor \
 
 The following tables lists the more common configurable parameters of the chart and their default values for installing the Container sensor as a Sidecar.
 
-| Parameter                                        | Description                                                             | Default                                   |
-|:-------------------------------------------------|:------------------------------------------------------------------------|:----------------------------------------- |
-| `container.enabled`                              | Enable installation on the Kubernetes node                              | `false`                                   |
-| `container.disableNSInjection`                   | Disable injection for all Namespaces                                    | `false`                                   |
-| `container.disablePodInjection`                  | Disable injection for all Pods                                          | `false`                                   |
-| `container.certExpiration`                       | Certificate validity duration in number of days                         | `3650`                                    |
-| `container.image.repository`                     | Falcon Sensor Node registry/image name                                  | `falcon-sensor`                           |
-| `container.image.tag`                            | The version of the official image to use                                | `latest`                                  |
-| `container.image.pullPolicy`                     | Policy for updating images                                              | `Always`                                  |
-| `container.image.pullSecrets.enable`             | Enable pull secrets for private registry                                | `false`                                   |
-| `container.image.pullSecrets.namespaces`         | Namespaces that should the Falcon sensor from an authenticated registry | None                                      |
-| `container.image.pullSecrets.registryConfigJSON` | base64 encoded docker config json for the pull secret                   | None                                      |
-| `falcon.cid`                                     | CrowdStrike Customer ID (CID)                                           | None       (Required)                     |
+| Parameter                                        | Description                                                             | Default         |
+| :----------------------------------------------- | :---------------------------------------------------------------------- | :-------------- |
+| `container.enabled`                              | Enable installation on the Kubernetes node                              | `false`         |
+| `container.disableNSInjection`                   | Disable injection for all Namespaces                                    | `false`         |
+| `container.disablePodInjection`                  | Disable injection for all Pods                                          | `false`         |
+| `container.certExpiration`                       | Certificate validity duration in number of days                         | `3650`          |
+| `container.image.repository`                     | Falcon Sensor Node registry/image name                                  | `falcon-sensor` |
+| `container.image.tag`                            | The version of the official image to use                                | `latest`        |
+| `container.image.pullPolicy`                     | Policy for updating images                                              | `Always`        |
+| `container.image.pullSecrets.enable`             | Enable pull secrets for private registry                                | `false`         |
+| `container.image.pullSecrets.namespaces`         | Namespaces that should the Falcon sensor from an authenticated registry | None            |
+| `container.image.pullSecrets.registryConfigJSON` | base64 encoded docker config json for the pull secret                   | None            |
+| `falcon.cid`                                     | CrowdStrike Customer ID (CID)                                           | None            |
 
-`falcon.cid` and `container.image.repository` are required values.
+`container.image.repository` is a required value.
 
 ### Uninstall Helm Chart
 To uninstall, run the following command:

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -12,7 +12,6 @@ metadata:
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 data:
-  FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
   {{- range $key, $value := .Values.falcon }}
   {{- if and ($value) (ne $key "cid") }}
   FALCONCTL_OPT_{{ $key | upper }}: {{ $value | quote }}

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -66,6 +66,12 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-sensor.fullname" . }}-config
+        - secretRef:
+            {{- if .Values.existingSecretName }}
+            name: {{ .Values.existingSecretName }}
+            {{- else }}
+            name: {{ include "falcon-sensor.fullname" . }}-secret
+            {{- end }}
         ports:
         - name: https
           containerPort: {{ .Values.container.injectorPort }}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -115,6 +115,12 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-sensor.fullname" . }}-config
+        - secretRef:
+            {{- if .Values.existingSecretName }}
+            name: {{ .Values.existingSecretName }}
+            {{- else }}
+            name: {{ include "falcon-sensor.fullname" . }}-secret
+            {{- end }}
       volumes:
         - name: dev
           hostPath:

--- a/helm-charts/falcon-sensor/templates/secret.yaml
+++ b/helm-charts/falcon-sensor/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.falcon.cid }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falcon-sensor.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: "{{ include "falcon-sensor.name" . }}"
+    app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "container_sensor"
+    crowdstrike.com/provider: crowdstrike
+    helm.sh/chart: {{ include "falcon-sensor.chart" . }}
+stringData:
+  FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
+{{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -2,32 +2,17 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
-        "falcon": {
-            "type": "object",
-            "required": [
-                "cid"
-              ],
-            "properties": {
-                "cid": {
-                    "type": "string",
-                    "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
-                    "example": [
-                        "1234567890ABCDEF1234567890ABCDEF-12"
-                    ]
-                }
-            }
-        },
         "node": {
             "type": "object",
             "required": [
                 "enabled"
-              ],
+            ],
             "properties": {
                 "daemonset": {
                     "type": "object",
                     "required": [
                         "updateStrategy"
-                      ],
+                    ],
                     "properties": {
                         "annotations": {
                             "type": "object"
@@ -66,7 +51,7 @@
                         "repository",
                         "pullPolicy",
                         "tag"
-                      ],
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string",
@@ -102,7 +87,7 @@
             "type": "object",
             "required": [
                 "enabled"
-              ],
+            ],
             "properties": {
                 "certExpiration": {
                     "type": "integer",
@@ -132,7 +117,7 @@
                         "repository",
                         "pullPolicy",
                         "tag"
-                      ],
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string",
@@ -142,7 +127,7 @@
                         "pullSecrets": {
                             "type": "object",
                             "properties": {
-                                 "enable": {
+                                "enable": {
                                     "type": "boolean",
                                     "default": "false"
                                 }
@@ -175,5 +160,34 @@
                 }
             }
         }
-    }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "falcon": {
+                    "type": "object",
+                    "required": [
+                        "cid"
+                    ],
+                    "properties": {
+                        "cid": {
+                            "type": "string",
+                            "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
+                            "example": [
+                                "1234567890ABCDEF1234567890ABCDEF-12"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "properties": {
+                "existingSecretName": {
+                    "type": "string",
+                    "description": "The name of an existing secret in which the FALCONCTL_OPT_CID key is set."
+                }
+            }
+        }
+    ]
 }

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -84,15 +84,15 @@ container:
     tag: "latest"
 
   resources:
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
     requests:
       cpu: 10m
       memory: 20Mi
 
 falcon:
-  cid:
+  cid: null
   aid:
   apd:
   aph:
@@ -103,3 +103,5 @@ falcon:
   billing:
   tags:
   provisioning_token:
+
+existingSecretName:

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -92,7 +92,7 @@ container:
       memory: 20Mi
 
 falcon:
-  cid: null
+  cid:
   aid:
   apd:
   aph:

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -104,4 +104,6 @@ falcon:
   tags:
   provisioning_token:
 
+# When set, uses an existing secret to inject environment variablesto the Falcon sensor.
+# If used, secret object must include key FALCONCTL_OPT_CID
 existingSecretName:


### PR DESCRIPTION
To fulfill the CID portion of #43, this PR moves the `falcon.cid` value to a secret object created by Helm. 

Additionally, this provides a field `existingSecretName` for a user to leverage an existing Kubernetes Secret for the Deployment/Daemonset to point to. This allows users to leverage other secret management solutions to create the secret object and keep the CID out of source control, where values files may be stored.