### PR TITLE
Enable and Allow the customization of serviceAccountName

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.1
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.7.1
+appVersion: 1.8.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/clusterrolebinding.yaml
+++ b/helm-charts/falcon-sensor/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ subjects:
   name: system:authenticated
 {{- end }}
 - kind: ServiceAccount
-  name: crowdstrike-falcon-sa
+  name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -93,6 +93,7 @@ spec:
       - name: {{ include "falcon-sensor.name" . }}-tls-certs
         secret:
           secretName: {{ include "falcon-sensor.name" . }}-tls
+      serviceAccountName: {{ .Values.serviceAccount }}
 ---
 apiVersion: v1
 kind: Secret

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -115,7 +115,7 @@ spec:
         - name: falconstore
           hostPath:
             path: /opt/CrowdStrike/falconstore
-      serviceAccountName: crowdstrike-falcon-sa
+      serviceAccountName: {{ .Values.serviceAccount }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
       hostNetwork: true
       hostPID: true

--- a/helm-charts/falcon-sensor/templates/node_scc.yaml
+++ b/helm-charts/falcon-sensor/templates/node_scc.yaml
@@ -31,7 +31,7 @@ requiredDropCapabilities:
 defaultAddCapabilities:
 allowedCapabilities:
 users:
-- crowdstrike-falcon-sa
+- {{ .Values.serviceAccount }}
 groups:
 volumes:
 - configMap

--- a/helm-charts/falcon-sensor/templates/serviceaccount.yaml
+++ b/helm-charts/falcon-sensor/templates/serviceaccount.yaml
@@ -1,11 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: crowdstrike-falcon-sa
+  name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "falcon-sensor.name" . }}
-    app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: "all_sensors"

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -6,7 +6,7 @@
             "type": "object",
             "required": [
                 "cid"
-              ],
+            ],
             "properties": {
                 "cid": {
                     "type": "string",
@@ -21,13 +21,13 @@
             "type": "object",
             "required": [
                 "enabled"
-              ],
+            ],
             "properties": {
                 "daemonset": {
                     "type": "object",
                     "required": [
                         "updateStrategy"
-                      ],
+                    ],
                     "properties": {
                         "annotations": {
                             "type": "object"
@@ -66,7 +66,7 @@
                         "repository",
                         "pullPolicy",
                         "tag"
-                      ],
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string",
@@ -102,7 +102,7 @@
             "type": "object",
             "required": [
                 "enabled"
-              ],
+            ],
             "properties": {
                 "certExpiration": {
                     "type": "integer",
@@ -132,7 +132,7 @@
                         "repository",
                         "pullPolicy",
                         "tag"
-                      ],
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string",
@@ -142,7 +142,7 @@
                         "pullSecrets": {
                             "type": "object",
                             "properties": {
-                                 "enable": {
+                                "enable": {
                                     "type": "boolean",
                                     "default": "false"
                                 }
@@ -174,6 +174,9 @@
                     }
                 }
             }
+        },
+        "serviceAccount": {
+            "type": "string"
         }
     }
 }

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -93,12 +93,14 @@ container:
     tag: "latest"
 
   resources:
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
     requests:
       cpu: 10m
       memory: 20Mi
+
+serviceAccount: crowdstrike-falcon-sa
 
 falcon:
   cid:


### PR DESCRIPTION
- [Fix] the hardcoded serviceAccountName in the daemonset
- [Fix] the hardcoded serviceAccountName in the clusterrolebinding
- [Fix] the hardcoded serviceAccountName in the SecurityContextConstraints
- [Fix] the hardcoded serviceAccountName in the ServiceAccount
- [Update] the values schema to support the serviceAccountName at root of values
- [Update] the ServiceAccount creation based on values (default : true as the account was created before but not used)
- [Add] the usage of the serviceAccountName for the injector
- [Add] Values : add the custom value for the serviceAccountName

Those changes allows the Falcon Container to be deployed on GKE cluster with Workload Identity (config actually recommended and not yet enforced on GCP side)
https://cloud.google.com/iam/docs/best-practices-for-using-workload-identity-federation

it should also support AWS OIDC as a K8S serviceAccount with annotations (for role binding) is needed