### PR TITLE
Fixes an issue with the node.image.pullSecrets property

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.6.0
+appVersion: 1.6.1
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -74,7 +74,7 @@
                             "pattern": "^(Always|Never|IfNotPresent)$"
                         },
                         "pullSecrets": {
-                            "type": "object"
+                            "type": "array"
                         },
                         "repository": {
                             "type": "string"

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -25,7 +25,7 @@ node:
   image:
     repository: falcon-node-sensor
     pullPolicy: Always
-    pullSecrets: {}
+    pullSecrets: []
     # Overrides the image tag whose default is the chart appVersion.
     tag: "latest"
 


### PR DESCRIPTION
This is related to https://github.com/CrowdStrike/falcon-helm/issues/92

The property, as defined, expects an object-type value. However, the Pod spec expects an array-type value for the "imagePullSecrets" property. Source: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret

In the current state, if we pass an object to node.image.pullSecrets, we pass schema validation but receive an error from Kubernetes:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(DaemonSet.spec.template.spec.imagePullSecrets): invalid type for io.k8s.api.core.v1.PodSpec.imagePullSecrets: got "map", expected "array"
```

Conversely, if we pass an array, we fail schema validation:
```
coalesce.go:199: warning: cannot overwrite table with non table for pullSecrets (map[])
Error: values don't meet the specifications of the schema(s) in the following chart(s):
falcon-sensor:
- node.image.pullSecrets: Invalid type. Expected: object, given: array
```

Therefore it is impossible to deploy a private image in versions 1.4.1+ of the chart.