### PR TITLE
Fix namespace selector in webhook to exclude release namespace + move master anti-affinity to preference

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.0
+version: 1.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.11.0
+appVersion: 1.12.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -54,6 +54,10 @@ spec:
                 operator: In
                 values:
                 - linux
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       securityContext:
@@ -185,7 +189,7 @@ webhooks:
         operator: {{ if .Values.container.disableNSInjection }}In{{ else }}NotIn{{- end }}
         values:
           - {{ if .Values.container.disableNSInjection }}enabled{{ else }}disabled{{- end }}
-      - key: "name"
+      - key: kubernetes.io/metadata.name
         operator: "NotIn"
         values:
         - {{ .Release.Namespace }}


### PR DESCRIPTION
Fixes error with the injector replicaset where it would fail to create pods with the following error:

> Error creating: Internal error occurred: failed calling webhook "falcon-sensor-injector.falcon-system.svc": failed to call webhook: Post "https://falcon-sensor-injector.falcon-system.svc:443/mutate?timeout=30s": no endpoints available for service "falcon-sensor-injector"

Also moves the anti-affinity on masters for node scheduling to soft rule / preference to allow scheduling in small / single node clusters where all nodes have master role.