### PR TITLE
Support service account annotations

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.14.1
+version: 1.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.14.1
+appVersion: 1.15.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/clusterrolebinding.yaml
+++ b/helm-charts/falcon-sensor/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ subjects:
   name: system:authenticated
 {{- end }}
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount }}
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -156,7 +156,7 @@ spec:
           path: {{ .Values.container.azure.azureConfig }}
           type: File
       {{- end }}
-      serviceAccountName: {{ .Values.serviceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
 ---
 apiVersion: v1
 kind: Secret

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -124,7 +124,7 @@ spec:
         - name: falconstore
           hostPath:
             path: /opt/CrowdStrike/falconstore
-      serviceAccountName: {{ .Values.serviceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
       hostNetwork: true
       hostPID: true

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -102,7 +102,7 @@ spec:
       - name: opt-crowdstrike
         hostPath:
           path: /opt
-      serviceAccountName: {{ .Values.serviceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
 {{- end }}
 

--- a/helm-charts/falcon-sensor/templates/node_scc.yaml
+++ b/helm-charts/falcon-sensor/templates/node_scc.yaml
@@ -31,7 +31,7 @@ requiredDropCapabilities:
 defaultAddCapabilities:
 allowedCapabilities:
 users:
-- {{ .Values.serviceAccount }}
+- {{ .Values.serviceAccount.name }}
 groups:
 volumes:
 - configMap

--- a/helm-charts/falcon-sensor/templates/serviceaccount.yaml
+++ b/helm-charts/falcon-sensor/templates/serviceaccount.yaml
@@ -1,10 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount }}
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: "all_sensors"
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -16,7 +16,10 @@
                     ]
                 },
                 "trace": {
-                    "type": ["null", "string"],
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "pattern": "^(|none|err|warn|info|debug)$"
                 }
             }
@@ -53,7 +56,17 @@
                             "pattern": "^[0-9]+$"
                         },
                         "serviceAccountName": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "default": "crowdstrike-falcon-sa"
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "default": {}
+                                }
+                            }
                         }
                     }
                 },
@@ -73,7 +86,10 @@
                     ],
                     "properties": {
                         "registryConfigJSON": {
-                            "type": ["null", "string"]
+                            "type": [
+                                "null",
+                                "string"
+                            ]
                         },
                         "pullPolicy": {
                             "type": "string",
@@ -81,7 +97,10 @@
                             "pattern": "^(Always|Never|IfNotPresent)$"
                         },
                         "pullSecrets": {
-                            "type": ["null", "string"]
+                            "type": [
+                                "null",
+                                "string"
+                            ]
                         },
                         "repository": {
                             "type": "string"
@@ -183,10 +202,16 @@
                                     "default": "false"
                                 },
                                 "namespaces": {
-                                    "type": ["null", "string"]
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
                                 },
                                 "registryConfigJSON": {
-                                    "type": ["null", "string"]
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
                                 }
                             }
                         },
@@ -218,7 +243,22 @@
             }
         },
         "serviceAccount": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": "crowdstrike-falcon-sa"
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "examples": [
+                        {
+                            "iam.gke.io/gcp-service-account": "my-service-account@my-project.iam.gserviceaccount.com"
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -125,8 +125,7 @@ container:
 
 serviceAccount:
   name: crowdstrike-falcon-sa
-  # annotations:
-  #   iam.gke.io/gcp-service-account: my-service-account@my-project.iam.gserviceaccount.com
+  annotations: {}
 
 falcon:
   cid:

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -123,7 +123,10 @@ container:
       cpu: 10m
       memory: 20Mi
 
-serviceAccount: crowdstrike-falcon-sa
+serviceAccount:
+  name: crowdstrike-falcon-sa
+  # annotations:
+  #   iam.gke.io/gcp-service-account: my-service-account@my-project.iam.gserviceaccount.com
 
 falcon:
   cid:


### PR DESCRIPTION
This commit supports annotations which will allow the Falcon container sensor to utilize both GCP [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to) and (probably) AWS OIDC. https://github.com/CrowdStrike/falcon-helm/pull/91 allowed for the renaming of service accounts however annotations are required.