### PR TITLE
fix: tolerate taints on control-plane nodes only (by default)

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.2
+version: 1.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.15.2
+appVersion: 1.16.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -70,15 +70,12 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
+    {{- if .Values.node.daemonset.tolerations }}    
       tolerations:
-      # this toleration is to have the daemonset runnable on all nodes
-      - operator: Exists
-        effect: NoExecute
-      - operator: Exists
-        effect: NoSchedule
       {{- with .Values.node.daemonset.tolerations }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- end }}  
       nodeSelector:
         kubernetes.io/os: linux
       initContainers:

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -66,15 +66,12 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
+    {{- if .Values.node.daemonset.tolerations }}    
       tolerations:
-      # this toleration is to have the daemonset runnable on all nodes
-      - operator: Exists
-        effect: NoExecute
-      - operator: Exists
-        effect: NoSchedule
       {{- with .Values.node.daemonset.tolerations }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+    {{- end }}  
       nodeSelector:
         kubernetes.io/os: linux
       initContainers:

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -13,8 +13,16 @@ node:
     # additionals labels
     labels: {}
 
-    # additional tolerations for server scheduling to nodes with taints
-    tolerations: []
+    tolerations:
+    # We want to schedule on control plane nodes where they are accessible
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+    # Future taint for K8s >=1.24
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    # Daemonsets automatically get additional tolerations: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 
     # Update strategy to role out new daemonset configuration to the nodes.
     updateStrategy: RollingUpdate


### PR DESCRIPTION
There are scenarios, albeit few and far between, where the daemonset pod would get scheduled on nodes that were not supported (or intended to deployed to) e.g. Fargate nodes.

This change also allows for complete control of the tolerations set on the daemonset pods (excluding those set by the K8s API itself)