### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,9 +1,11 @@
 name: Release Helm Charts
 
 on:
-  release:
-    types:
-      - created
+  push:
+    branches:
+      - main
+    paths:
+      - 'helm-charts/**'
 
 jobs:
   release:
@@ -24,24 +26,10 @@ jobs:
         with:
           version: v3.8.1
 
-      - name: Create Helm release artifacts
-        run: |
-          helm package ./helm-charts/falcon-sensor
-
-      - name: Release artifacts to GitHub
-        uses: ncipollo/release-action@v1
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
         with:
-          artifacts: ./falcon*.tgz
-          allowUpdates: true
-          name: ${{ github.event.release.tag_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: helm-charts
 
-      - name: Update index.yaml
-        run: |
-          git fetch origin gh-pages
-          git reset --hard HEAD
-          git checkout gh-pages
-          helm repo index . --url https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }} --merge index.yaml
-          git add index.yaml
-          git commit -m "Update index.yaml to latest Helm release"
-          git push origin gh-pages
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,6 +1,9 @@
 name: Lint and Test Helm Charts
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'helm-charts/**'
 
 jobs:
   lint-test:
@@ -15,10 +18,6 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.8.1
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1


### PR DESCRIPTION
- Auto-release helm charts on chart version change after merge into main
- Only run when there are changes in `helm-charts` dir