### PR TITLE
Add webhook replicas in values

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.2
+version: 1.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.2
+appVersion: 1.17.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -38,7 +38,7 @@ metadata:
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.container.replicas }}
   selector:
     matchLabels:
       app: {{ include "falcon-sensor.name" . }}-injector

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -225,6 +225,11 @@
                         }
                     }
                 },
+                "replicas": {
+                    "type": "integer",
+                    "default": 1,
+                    "minimum": 1
+                },
                 "resources": {
                     "type": "object",
                     "properties": {

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -57,6 +57,9 @@ container:
   # When enabled, Helm chart deploys the Falcon Container Sensor to Pods through Webhooks
   enabled: false
 
+  # Configure the number of replicas for the mutating webhook backend
+  replicas: 1
+
   # Auto update the certificates every time there is an update
   autoCertificateUpdate: true
 


### PR DESCRIPTION
Hi,

This PR allows to configure the number of replicas for the webhook backend. The default value is 1 as before, but it's important, especially in production clusters, to have multiple replicas in order to be compliant with best practices https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#availability

Please could you review it?
Thanks