### PR TITLE
Improvement: Use ChartApp Version as default for Images

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.6
+version: 1.17.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/falcon-sensor/README.md
+++ b/helm-charts/falcon-sensor/README.md
@@ -103,8 +103,8 @@ The following tables lists the more common configurable parameters of the chart 
 |:--------------------------------|:---------------------------------------------------------------------|:--------------------------------------------------------- |
 | `node.enabled`                  | Enable installation on the Kubernetes node                           | `true`                                                    |
 | `node.image.repository`         | Falcon Sensor Node registry/image name                               | `falcon-node-sensor`                                      |
-| `node.image.tag`                | The version of the official image to use                             | `latest`                                                  |
-| `node.image.pullPolicy`         | Policy for updating images                                           | `Always`                                                  |
+| `node.image.tag`                | The version of the official image to use                             | ``                                                        |
+| `node.image.pullPolicy`         | Policy for updating images                                           | `IfNotPresent`                                            |
 | `node.image.pullSecrets`        | Pull secrets for private registry                                    | None       (Conflicts with node.image.registryConfigJSON) |
 | `node.image.registryConfigJSON` | base64 encoded docker config json for the pull secret                | None       (Conflicts with node.image.pullSecrets)        |
 | `falcon.cid`                    | CrowdStrike Customer ID (CID)                                        | None       (Required)                                     |
@@ -173,8 +173,8 @@ The following tables lists the more common configurable parameters of the chart 
 | `container.certExpiration`                       | Certificate validity duration in number of days                             | `3650`                       |
 | `container.registryCertSecret`                   | Name of generic Secret with additional CAs for external registries          | None                         |
 | `container.image.repository`                     | Falcon Sensor Node registry/image name                                      | `falcon-sensor`              |
-| `container.image.tag`                            | The version of the official image to use                                    | `latest`                     |
-| `container.image.pullPolicy`                     | Policy for updating images                                                  | `Always`                     |
+| `container.image.tag`                            | The version of the official image to use                                    | ``                           |
+| `container.image.pullPolicy`                     | Policy for updating images                                                  | `IfNotPresent`               |
 | `container.image.pullSecrets.enable`             | Enable pull secrets for private registry                                    | `false`                      |
 | `container.image.pullSecrets.namespaces`         | List of Namespaces to pull the Falcon sensor from an authenticated registry | None                         |
 | `container.image.pullSecrets.allNamespaces`      | Use Helm's lookup function to deploy the pull secret to all namespaces      | `false`                      |

--- a/helm-charts/falcon-sensor/questions.yaml
+++ b/helm-charts/falcon-sensor/questions.yaml
@@ -34,22 +34,22 @@ questions:
     group: "Falcon Node settings"
 
   - variable: node.image.tag
-    description: "Container registry image tag. Defaults to 'latest'."
+    description: "Container registry image tag. Default is the chart appVersion."
     required: true
     type: string
-    default: "latest"
+    default: ""
     label: Image Tag
     group: "Falcon Node settings"
 
   - variable: node.image.pullPolicy
-    description: "The default image pullPolicy. Defaults to 'Always'."
+    description: "The default image pullPolicy. Defaults to 'IfNotPresent'."
     required: false
     type: enum
     options:
       - IfNotPresent
       - Always
       - Never
-    default: Always
+    default: IfNotPresent
     label: Image pullPolicy
     group: "Falcon Node settings"
 
@@ -84,22 +84,22 @@ questions:
     group: "Falcon Container settings"
 
   - variable: container.image.tag
-    description: "Container registry image tag. Defaults to 'latest'."
+    description: "Container registry image tag. Default is the chart appVersion."
     required: true
     type: string
-    default: "latest"
+    default: ""
     label: Image Tag
     group: "Falcon Container settings"
 
   - variable: container.image.pullPolicy
-    description: "The default image pullPolicy. Defaults to 'Always'."
+    description: "The default image pullPolicy. Defaults to 'IfNotPresent'."
     required: false
     type: enum
     options:
       - IfNotPresent
       - Always
       - Never
-    default: Always
+    default: IfNotPresent
     label: Image pullPolicy
     group: "Falcon Container settings"
 

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
   {{- if .Values.container.enabled }}
   CP_NAMESPACE: {{ .Release.Namespace }}
   FALCON_IMAGE_PULL_POLICY: "{{ .Values.container.image.pullPolicy }}"
-  FALCON_IMAGE: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
+  FALCON_IMAGE: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag | default .Chart.AppVersion }}"
   FALCON_INJECTOR_LISTEN_PORT: "{{ .Values.container.injectorPort }}"
   {{- if .Values.container.image.pullSecrets.enable }}
   FALCON_IMAGE_PULL_SECRET: {{ include "falcon-sensor.fullname" . }}-pull-secret

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -84,8 +84,8 @@ spec:
       {{- if .Values.container.azure.enabled }}
       initContainers:
       - name: {{ include "falcon-sensor.name" . }}-init-container
-        image: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
-        imagePullPolicy: Always
+        image: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.container.image.pullPolicy }}"
         command: ['bash', '-c', "cp /run/azure.json /tmp/CrowdStrike/; chmod a+r /tmp/CrowdStrike/azure.json"]
         securityContext:
           runAsUser: 0
@@ -100,7 +100,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "falcon-sensor.name" . }}-injector
-        image: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
+        image: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.container.image.pullPolicy }}"
         command: ["injector"]
         envFrom:

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
       # a file volume ensures that AID is preserved across container
       # restarts.
       - name: init-falconstore
-        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"
+        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag | default .Chart.AppVersion }}"
         command: ["/bin/bash"]
         args: [-c, 'mkdir -p /opt/CrowdStrike && touch /opt/CrowdStrike/falconstore']
         volumeMounts:
@@ -93,7 +93,7 @@ spec:
             mountPath: /opt
       containers:
       - name: falcon-node-sensor
-        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"
+        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.node.image.pullPolicy }}"
         # Various pod security context settings. Bear in mind that many of these have an impact
         # on the Falcon Sensor working correctly.

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -77,7 +77,7 @@ spec:
         kubernetes.io/os: linux
       initContainers:
       - name: cleanup-opt-crowdstrike
-        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"
+        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag | default .Chart.AppVersion }}"
         command: ["rm", "-rf", "/opt/CrowdStrike"]
         volumeMounts:
           - name: opt-crowdstrike
@@ -89,7 +89,7 @@ spec:
           allowPrivilegeEscalation: true
       containers:
       - name: cleanup-sleep
-        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"
+        image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag | default .Chart.AppVersion }}"
         command: ["sleep", "10"]
         securityContext:
           runAsUser: 0

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -96,7 +96,7 @@
                         },
                         "pullPolicy": {
                             "type": "string",
-                            "default": "Always",
+                            "default": "IfNotPresent",
                             "pattern": "^(Always|Never|IfNotPresent)$"
                         },
                         "pullSecrets": {
@@ -110,7 +110,7 @@
                         },
                         "tag": {
                             "type": "string",
-                            "default": "latest"
+                            "default": ""
                         }
                     }
                 },
@@ -200,7 +200,7 @@
                     "properties": {
                         "pullPolicy": {
                             "type": "string",
-                            "default": "Always",
+                            "default": "IfNotPresent",
                             "pattern": "^(Always|Never|IfNotPresent)$"
                         },
                         "pullSecrets": {
@@ -233,7 +233,7 @@
                         },
                         "tag": {
                             "type": "string",
-                            "default": "latest"
+                            "default": ""
                         }
                     }
                 },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -35,11 +35,11 @@ node:
 
   image:
     repository: falcon-node-sensor
-    pullPolicy: Always
-    pullSecrets:
+    pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "latest"
+    tag: ""
 
+    pullSecrets:
     # Value must be base64. This setting conflicts with node.image.pullSecrets
     # The base64 encoded string of the docker config json for the pull secret can be
     # gotten through:
@@ -115,7 +115,9 @@ container:
 
   image:
     repository: falcon-sensor
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
     # Set to true if connecting to a registry that requires authentication
     pullSecrets:
       enable: false
@@ -135,9 +137,6 @@ container:
       # gotten through:
       # $ cat ~/.docker/config.json | base64 -
       registryConfigJSON:
-
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: "latest"
 
   resources:
     # limits:


### PR DESCRIPTION
Hi,

We noticed some problems with the current version of your helm chart.

At first, we block in our environment the latest tag due to Security Reasons and Rollback Problems.
The ‘latest’ tag does not actually mean latest, it doesn’t mean anything. It's also not possible at the moment to Rollback to an older Version if anyone noticed problems. In older helm chart versions is also the latest tag used and this mean at the end you Rollback from latest to latest. 

The second problem is a possible version drift between Nodes. If a new version were released and re-tagged with "latest"
it could happen that multiple Versions are running on the different Nodes with out knowing this. You only see that the latest tag/version is used. It's hard to identify the correct version at the end if some node has trouble. 
You need to calculate the sha256 hashes to know which versions is used on the different Nodes.

You describe in your values.yaml that an semantic versioning is used "ChartApp Version", but this is not the Case.
https://github.com/CrowdStrike/falcon-helm/blob/675a957c7acea0d28a86d4e1c55db53804b00f92/helm-charts/falcon-sensor/values.yaml#L40-L41
https://github.com/CrowdStrike/falcon-helm/blob/675a957c7acea0d28a86d4e1c55db53804b00f92/helm-charts/falcon-sensor/values.yaml#L139-L140

You describe also to use a [specific Version to use different Sensor Versions](https://github.com/CrowdStrike/falcon-helm/blob/main/helm-charts/falcon-sensor/README.md#helm-chart-support-for-falcon-sensor-versions). But, this is at the moment also not working due to the used "latest" Image Tag.

The only thing that is not clear to me at the moment is, which Sensor Version is the current release.
I think it's not the current Chart App Version, or?
https://github.com/CrowdStrike/falcon-helm/blob/675a957c7acea0d28a86d4e1c55db53804b00f92/helm-charts/falcon-sensor/Chart.yaml#L23

You describe in the [Readme.MD](https://github.com/CrowdStrike/falcon-helm/blob/main/helm-charts/falcon-sensor/README.md#L30-L31) other semantic Versions.

| Helm chart Version | Falcon Sensor Version |
|:-------------------|:----------------------|
| `<= 1.6.x`         | `<= 6.34.x`           |
| `>= 1.7.x`         | `>= 6.35.x`           |

**Feel free to update this PR and to set the correct ChartApp Version that matches to current Sensors Version.**

Last but not least, we switched also Image Pull Policy to 'ifNotPresent'. This reduced the ImagePulls and it prevents to reach the rate limit on docker hub.


Signed-off-by: dschunack <dschunack@web.de>