### PR TITLE
[Feature] Add possibilty to set resources and PriorityClass for Node DaemonSet

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.7
+version: 1.17.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.7
+appVersion: 1.17.8
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -114,6 +114,10 @@ spec:
         volumeMounts:
           - name: falconstore
             mountPath: /opt/CrowdStrike/falconstore
+      {{- if .Values.node.daemonset.resources }}
+        resources:
+{{ toYaml .Values.node.daemonset.resources | indent 10 }}
+      {{- end }}
       volumes:
         - name: falconstore-dir
           hostPath:
@@ -124,6 +128,9 @@ spec:
             path: /opt/CrowdStrike/falconstore
       serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
+    {{- if .Values.node.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.node.daemonset.priorityClassName }}
+    {{- end }}
       hostNetwork: true
       hostPID: true
       hostIPC: true

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -48,6 +48,12 @@
                         "tolerations": {
                             "type": "array"
                         },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
                         "updateStrategy": {
                             "type": "string",
                             "default": "RollingUpdate",

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -16,6 +16,17 @@ node:
     # additionals labels
     labels: {}
 
+    # Assign a PriorityClassName to pods if set
+    priorityClassName: ""
+
+    # Define resources requests and limits for single Pods.
+    # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    #
+    resources: {}
+      # requests:
+      #   cpu: 10m
+      #   memory: 30Mi
+
     tolerations:
     # We want to schedule on control plane nodes where they are accessible
     - key: "node-role.kubernetes.io/master"


### PR DESCRIPTION
Hi,

At the moment it's not possible to set the PriorityClass and Resources for the DaemonSet.
This had some negative effects for the PODs of the DaemonSet.

POD are running in QoS Class "BestEffort" and if a Node-pressure signal occurse the POD will be evicted first.

Without a PriorityClass it's not Guaranteed that a POD will started on the Nodes. Short exmaple: If your reach the POD Limit on smaller Nodes, the POD will not start and stucks in the "Pending" state. With PriorityClass we can Guarantee that the POD started at any time on the Nodes. POD with a lower or without an PriorityClass are automatically evecited to Guarantee the start of the POD.

It looks like this at the moment:

```yaml
% kubectl -n falcon-system get pods -o wide                
NAME                  READY   STATUS    RESTARTS   AGE   IP               NODE                                              NOMINATED NODE   READINESS GATES
falcon-sensor-29l6f   0/1     Pending   0          36m   <none>           <none>                                            <none>           <none>
falcon-sensor-c8mq7   1/1     Running   0          10d   10.194.128.39    ip-10-194-128-39.eu-central-1.compute.internal    <none>           <none>
falcon-sensor-c9fxq   1/1     Running   0          21h   10.194.129.53    ip-10-194-129-53.eu-central-1.compute.internal    <none>           <none>
```
```yaml
kubectl -n falcon-system describe pod falcon-sensor-22shf
Name:         falcon-sensor-22shf
Namespace:    falcon-system
QoS Class:                   BestEffort
```

I added both functionalities for the Node DaemonSet to Guarantee the start of the PODs at any time.

Files Changed in the falcon-sensor Chart:

- Charts.yaml
- values.yaml
- templates/daemonset.yaml
- values.schema.json

Signed-off-by: dschunack <dschunack@web.de>