### PR TITLE
Falcon Container - Allow customization of secret name

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.7
+version: 1.17.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.7
+appVersion: 1.17.8
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
   FALCON_IMAGE: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
   FALCON_INJECTOR_LISTEN_PORT: "{{ .Values.container.injectorPort }}"
   {{- if .Values.container.image.pullSecrets.enable }}
-  FALCON_IMAGE_PULL_SECRET: {{ include "falcon-sensor.fullname" . }}-pull-secret
+  FALCON_IMAGE_PULL_SECRET: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
   {{- end }}
   {{- if .Values.container.disablePodInjection }}
   INJECTION_DEFAULT_DISABLED: T

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -79,7 +79,7 @@ spec:
         runAsNonRoot: true
       {{- if .Values.container.image.pullSecrets.enable }}
       imagePullSecrets:
-        - name: {{ include "falcon-sensor.fullname" . }}-pull-secret
+        - name: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
       {{- end }}
       {{- if .Values.container.azure.enabled }}
       initContainers:

--- a/helm-charts/falcon-sensor/templates/container_secret.yaml
+++ b/helm-charts/falcon-sensor/templates/container_secret.yaml
@@ -4,13 +4,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "falcon-sensor.fullname" . }}-pull-secret
+  name: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
   namespace: {{ .Release.Namespace }}
 data:
   .dockerconfigjson: {{ $registry }}
 type: kubernetes.io/dockerconfigjson
 {{- if .Values.container.image.pullSecrets.namespaces }}
-{{- $name := (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
+{{- $name := ( .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .))) }}
 {{- $myns := split "," .Values.container.image.pullSecrets.namespaces -}}
 {{- if .Values.container.image.pullSecrets.allNamespaces }}
 {{- $myns = list -}}

--- a/helm-charts/falcon-sensor/templates/container_secret.yaml
+++ b/helm-charts/falcon-sensor/templates/container_secret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.container.enabled }}
 {{- if .Values.container.image.pullSecrets.enable }}
+{{- if not .Values.container.image.pullSecrets.name }}
 {{- $registry := .Values.container.image.pullSecrets.registryConfigJSON }}
 apiVersion: v1
 kind: Secret
@@ -28,6 +29,7 @@ metadata:
 data:
   .dockerconfigjson: {{ $registry }}
 type: kubernetes.io/dockerconfigjson
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -210,6 +210,12 @@
                                     "type": "boolean",
                                     "default": "false"
                                 },
+                                "name": {
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
                                 "allNamespaces": {
                                     "type": "boolean",
                                     "default": "false"

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -119,6 +119,7 @@ container:
     # Set to true if connecting to a registry that requires authentication
     pullSecrets:
       enable: false
+      name:
       # Configure the list of namespaces that should have access to pull the Falcon
       # sensor from a registry that requires authentication. This is a comma separated
       # list. For example:


### PR DESCRIPTION
In some deployment cases, secrets can be provisioned/updated by another method - this update allow to customize Falcon container secret name.