### PR TITLE
Modify function check in node psp template to enable PSP on v1.24 clusters

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.8
+version: 1.17.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.8
+appVersion: 1.17.9
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/node_psp.yaml
+++ b/helm-charts/falcon-sensor/templates/node_psp.yaml
@@ -1,6 +1,6 @@
 {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
-{{- if lt (int (semver .Capabilities.KubeVersion.Version).Minor) 24 }}
+{{- if lt (int (semver .Capabilities.KubeVersion.Version).Minor) 25 }}
 {{- if .Values.node.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy


### PR DESCRIPTION
Hey Team,

PSP's are being deprecated in v1.25, but they are still supported in v1.24. Please modify the second argument to 25 to enable PSP on v1.24 clusters, otherwise the deployment fails.

Cheers