### PR TITLE
Add nodeAffinity. Fix a few values

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.9
+version: 1.17.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.9
+appVersion: 1.17.10
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -84,7 +84,7 @@ spec:
         {{- with .Values.node.daemonset.nodeAffinity }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
-    {{- end }}  
+    {{- end }}
       initContainers:
       # This init container creates empty falconstore file so that when
       # it's mounted into the sensor-node-container, k8s would just use it

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -78,6 +78,13 @@ spec:
     {{- end }}  
       nodeSelector:
         kubernetes.io/os: linux
+    {{- if .Values.node.daemonset.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+        {{- with .Values.node.daemonset.nodeAffinity }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+    {{- end }}  
       initContainers:
       # This init container creates empty falconstore file so that when
       # it's mounted into the sensor-node-container, k8s would just use it

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -75,6 +75,13 @@ spec:
     {{- end }}  
       nodeSelector:
         kubernetes.io/os: linux
+    {{- if .Values.node.daemonset.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+        {{- with .Values.node.daemonset.nodeAffinity }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+    {{- end }}  
       initContainers:
       - name: cleanup-opt-crowdstrike
         image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -81,7 +81,7 @@ spec:
         {{- with .Values.node.daemonset.nodeAffinity }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
-    {{- end }}  
+    {{- end }}
       initContainers:
       - name: cleanup-opt-crowdstrike
         image: "{{ .Values.node.image.repository }}:{{ .Values.node.image.tag }}"

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -80,9 +80,6 @@
                     "type": "boolean",
                     "default": "true"
                 },
-                "fullnameOverride": {
-                    "type": "string"
-                },
                 "image": {
                     "type": "object",
                     "required": [
@@ -116,9 +113,6 @@
                             "default": "latest"
                         }
                     }
-                },
-                "nameOverride": {
-                    "type": "string"
                 },
                 "podAnnotations": {
                     "type": "object"
@@ -286,6 +280,12 @@
                     ]
                 }
             }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "fullnameOverride": {
+            "type": "string"
         }
     }
 }

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -48,6 +48,9 @@
                         "tolerations": {
                             "type": "array"
                         },
+                        "nodeAffinity": {
+                            "type": "object"
+                        },
                         "updateStrategy": {
                             "type": "string",
                             "default": "RollingUpdate",

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -27,6 +27,18 @@ node:
       effect: "NoSchedule"
     # Daemonsets automatically get additional tolerations: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 
+    # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    # Allow setting additional node selections e.g. processor type
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchExpressions:
+    #       - key: kubernetes.io/arch
+    #         operator: In
+    #         values:
+    #         - amd64
+    nodeAffinity: {}
+    
     # Update strategy to role out new daemonset configuration to the nodes.
     updateStrategy: RollingUpdate
 

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -58,11 +58,6 @@ node:
     # $ cat ~/.docker/config.json | base64 -
     registryConfigJSON:
 
-  # Override various naming aspects of this chart
-  # Only edit these if you know what you're doing
-  nameOverride: ""
-  fullnameOverride: ""
-
   podAnnotations: {}
 
   # How long to wait for Falcon pods to stop gracefully
@@ -175,3 +170,8 @@ falcon:
   billing:
   tags:
   provisioning_token:
+
+# Override various naming aspects of this chart
+# Only edit these if you know what you're doing
+nameOverride: ""
+fullnameOverride: ""

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -166,7 +166,6 @@ serviceAccount:
 
 falcon:
   cid:
-  aid:
   apd:
   aph:
   app:

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -38,7 +38,7 @@ node:
     #         values:
     #         - amd64
     nodeAffinity: {}
-    
+
     # Update strategy to role out new daemonset configuration to the nodes.
     updateStrategy: RollingUpdate
 


### PR DESCRIPTION
This adds nodeAffinity for the DS as an optional configuration. Allowing one to set additional node selections e.g. processor type:
```yaml
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/arch
            operator: In
            values:
            - amd64
```

Also, I removed an unusable falconctl and moved nameOverride and fullnameOverride to the root of the values since it was nested inside of the daemonset options and not used there.