### PR TITLE
GCP workload identity changes for deployment

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.12
+version: 1.17.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.12
+appVersion: 1.17.11
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.11
+version: 1.17.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.11
+appVersion: 1.17.12
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.10
+version: 1.17.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.10
+appVersion: 1.17.11
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -82,6 +82,7 @@ spec:
         - name: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
       {{- end }}
       {{- if .Values.container.azure.enabled }}
+      {{- if not .Values.container.gcp.enabled }}
       initContainers:
       - name: {{ include "falcon-sensor.name" . }}-init-container
         image: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
@@ -97,6 +98,24 @@ spec:
         - name: {{ include "falcon-sensor.name" . }}-azure-config
           mountPath: /run/azure.json
           readOnly: true
+      {{- end }}
+      {{- end }}
+      {{- if not .Values.container.azure.enabled }}
+      {{- if .Values.container.gcp.enabled }}
+      initContainers:
+      - name: {{ include "falcon-sensor.name" . }}-init-container
+        image: "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
+        imagePullPolicy: "Always"
+        command: 
+        - '/bin/bash'
+        - '-c'
+        - |
+          curl -sS -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token' --retry 30 --retry-connrefused --retry-max-time 60 --connect-timeout 3 --fail --retry-all-errors > /dev/null && exit 0 || echo 'Retry limit exceeded. Failed to wait for metadata server to be available. Check if the gke-metadata-server Pod in the kube-system namespace is healthy.' >&2; exit 1
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
+          privileged: false
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ include "falcon-sensor.name" . }}-injector

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -82,7 +82,6 @@ spec:
         - name: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
       {{- end }}
       {{- if .Values.container.azure.enabled }}
-      {{- if not .Values.container.gcp.enabled }}
       initContainers:
       - name: {{ include "falcon-sensor.name" . }}-init-container
         image: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
@@ -99,8 +98,6 @@ spec:
           mountPath: /run/azure.json
           readOnly: true
       {{- end }}
-      {{- end }}
-      {{- if not .Values.container.azure.enabled }}
       {{- if .Values.container.gcp.enabled }}
       initContainers:
       - name: {{ include "falcon-sensor.name" . }}-init-container
@@ -115,7 +112,6 @@ spec:
           runAsUser: 0
           runAsNonRoot: false
           privileged: false
-      {{- end }}
       {{- end }}
       containers:
       - name: {{ include "falcon-sensor.name" . }}-injector

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -158,6 +158,12 @@ spec:
           periodSeconds: 10
         resources:
             {{- toYaml .Values.resources | nindent 12 }}
+    {{- if .Values.container.tolerations }}    
+      tolerations:
+      {{- with .Values.container.tolerations }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
       volumes:
       - name: {{ include "falcon-sensor.name" . }}-tls-certs
         secret:

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -147,6 +147,18 @@
                         }
                     }
                 },
+                "gcp": {
+                    "type": "object",
+                    "required": [
+                        "enabled"
+                    ],
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": "false"
+                        }
+                    }
+                },
                 "autoCertificateUpdate": {
                     "type": "boolean",
                     "default": "true"

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -130,6 +130,9 @@
                 "enabled"
             ],
             "properties": {
+                "tolerations": {
+                    "type": "array"
+                },
                 "azure": {
                     "type": "object",
                     "required": [

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -83,6 +83,10 @@ container:
     # Path to the Kubernetes Azure config file on worker nodes
     azureConfig: /etc/kubernetes/azure.json
 
+  # GCP GKE workload identity init container
+  gcp:
+    enabled: false
+
   # Disable injection for all Namespaces
   disableNSInjection: false
 

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -151,6 +151,8 @@ container:
     # Overrides the image tag whose default is the chart appVersion.
     tag: "latest"
 
+  tolerations: []
+
   resources:
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
This PR enable an initContainer for GCP GKE setup in order to avoid issue with workload identity whenever a node pool is scaled down to 0 and then scaled up to > 0. Added also toleration for deployment setup.