### PR TITLE
[Feature] Add possibilty to the PriorityClass for the DaemonSet

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.15
+version: 1.17.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.15
+appVersion: 1.17.16
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -131,6 +131,9 @@ spec:
             path: /opt/CrowdStrike/falconstore
       serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
+    {{- if .Values.node.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.node.daemonset.priorityClassName }}
+    {{- end }}
       hostNetwork: true
       hostPID: true
       hostIPC: true

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -51,6 +51,9 @@
                         "nodeAffinity": {
                             "type": "object"
                         },
+                        "priorityClassName": {
+                            "type": "string"
+                        },
                         "updateStrategy": {
                             "type": "string",
                             "default": "RollingUpdate",

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -16,6 +16,9 @@ node:
     # additionals labels
     labels: {}
 
+    # Assign a PriorityClassName to pods if set
+    priorityClassName: ""
+
     tolerations:
     # We want to schedule on control plane nodes where they are accessible
     - key: "node-role.kubernetes.io/master"


### PR DESCRIPTION
Presently, setting the PriorityClass for the DaemonSet Pods is impossible. Pods may be evicted or not be scheduled at all in case of resource shortage on the worker nodes.

This PR enables the possibility of setting a PriorityClass, such as system-node-critical, via the Pod template and is an updated version of #150, excluding the aspects of resource requests and limits.