### PR TITLE
fix: ensure falconstore is a file when initContainer runs

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.17
+version: 1.17.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.17
+appVersion: 1.17.18
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -95,7 +95,7 @@ spec:
         image: "{{ include "falcon-sensor.image" . }}"
         imagePullPolicy: "{{ .Values.node.image.pullPolicy }}"
         command: ["/bin/bash"]
-        args: [-c, 'mkdir -p /opt/CrowdStrike && touch /opt/CrowdStrike/falconstore']
+        args: [-c, 'if [ -d "/opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /opt/CrowdStrike/falconstore; fi; mkdir -p /opt/CrowdStrike && touch /opt/CrowdStrike/falconstore']
         volumeMounts:
           - name: falconstore-dir
             mountPath: /opt


### PR DESCRIPTION
- In some cases when the operator was not deployed correctly, Kubernetes would create the falconstore file as a directory. This adds the capability for the initContainer to fix that by deleting falconstore if it is a directory when it should be a file.