### PR TITLE
fix: extend container PSP to broadly support all environments

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.18.1
+version: 1.18.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.18.1
+appVersion: 1.18.2
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/container_psp.yaml
+++ b/helm-charts/falcon-sensor/templates/container_psp.yaml
@@ -23,18 +23,16 @@ spec:
   - SYS_CHROOT
   - AUDIT_WRITE
   - CHOWN
-  - DAC_OVERRIDE
   - FOWNER
   - FSETID
   - NET_BIND_SERVICE
   - NET_RAW
-  - SETGID
   - SETPCAP
-  - SETUID
-  defaultAddCapabilities:
-  - SYS_PTRACE
   allowedCapabilities:
   - SYS_PTRACE
+  - DAC_OVERRIDE
+  - SETUID
+  - SETGID
   fsGroup:
     rule: RunAsAny
   hostIPC: false


### PR DESCRIPTION
It seems that EKS fargate strictly prohibits SYS_PTRACE, and as such, the container sensor falls back to SETUID and SETGID in those environments; however, having SYS_PTRACE in defaultAdd causes pod scheduling failures in that environment.

Further, Bottlerocket OS is supported by the container sensor, however the additional permission DAC_OVERRIDE is required.