### PR TITLE
breaking fix: move falcon.backend to node.backend

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.18.2
+version: 1.18.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.18.2
+appVersion: 1.18.3
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/README.md
+++ b/helm-charts/falcon-sensor/README.md
@@ -57,7 +57,6 @@ The following tables lists the Falcon Sensor configurable parameters and their d
 | `falcon.app`                | App Proxy Port (APP)                                      | None                  |
 | `falcon.trace`              | Set trace level. (`none`,`err`,`warn`,`info`,`debug`)     | `none`                |
 | `falcon.feature`            | Sensor Feature options                                    | None                  |
-| `falcon.backend`            | Choose sensor backend (`kernel`,`bpf`). Sensor 6.49+ only | None                  |
 | `falcon.message_log`        | Enable message log (true/false)                           | None                  |
 | `falcon.billing`            | Utilize default or metered billing                        | None                  |
 | `falcon.tags`               | Comma separated list of tags for sensor grouping          | None                  |
@@ -122,16 +121,17 @@ For more details please see the [falcon-helm](https://github.com/CrowdStrike/fal
 
 The following tables lists the more common configurable parameters of the chart and their default values for installing on a Kubernetes node.
 
-| Parameter                       | Description                                                          | Default                                                                |
-|:--------------------------------|:---------------------------------------------------------------------|:---------------------------------------------------------------------- |
-| `node.enabled`                  | Enable installation on the Kubernetes node                           | `true`                                                                 |
-| `node.image.repository`         | Falcon Sensor Node registry/image name                               | `falcon-node-sensor`                                                   |
-| `node.image.tag`                | The version of the official image to use                             | `latest`   (Use node.image.digest instead for security and production) |
-| `node.image.digest`             | The sha256 digest of the official image to use                       | None       (Use instead of the image tag for security and production)  |
-| `node.image.pullPolicy`         | Policy for updating images                                           | `Always`                                                               |
-| `node.image.pullSecrets`        | Pull secrets for private registry                                    | None       (Conflicts with node.image.registryConfigJSON)              |
-| `node.image.registryConfigJSON` | base64 encoded docker config json for the pull secret                | None       (Conflicts with node.image.pullSecrets)                     |
-| `falcon.cid`                    | CrowdStrike Customer ID (CID)                                        | None       (Required)                                                  |
+| Parameter                         | Description                                                            | Default                                                                 |
+| :-------------------------------- | :--------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| `node.enabled`                    | Enable installation on the Kubernetes node                             | `true`                                                                  |
+| `node.backend`                    | Choose sensor backend (`kernel`,`bpf`). Sensor 6.49+ only              | kernel                                                                  |
+| `node.image.repository`           | Falcon Sensor Node registry/image name                                 | `falcon-node-sensor`                                                    |
+| `node.image.tag`                  | The version of the official image to use                               | `latest`   (Use node.image.digest instead for security and production)  |
+| `node.image.digest`               | The sha256 digest of the official image to use                         | None       (Use instead of the image tag for security and production)   |
+| `node.image.pullPolicy`           | Policy for updating images                                             | `Always`                                                                |
+| `node.image.pullSecrets`          | Pull secrets for private registry                                      | None       (Conflicts with node.image.registryConfigJSON)               |
+| `node.image.registryConfigJSON`   | base64 encoded docker config json for the pull secret                  | None       (Conflicts with node.image.pullSecrets)                      |
+| `falcon.cid`                      | CrowdStrike Customer ID (CID)                                          | None       (Required)                                                   |
 
 `falcon.cid` and `node.image.repository` are required values.
 

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
   FALCONCTL_OPT_{{ $key | upper }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
+  {{- if and .Values.node.enabled .Values.node.backend }}
+  FALCONCTL_OPT_BACKEND: "{{ .Values.node.backend }}"
+  {{- end }}
   {{- if .Values.container.enabled }}
   CP_NAMESPACE: {{ .Release.Namespace }}
   FALCON_IMAGE_PULL_POLICY: "{{ .Values.container.image.pullPolicy }}"

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -15,13 +15,6 @@
                         "1234567890ABCDEF1234567890ABCDEF-12"
                     ]
                 },
-                "backend": {
-                    "type": [
-                        "null",
-                        "string"
-                    ],
-                    "pattern": "^(kernel|bpf)$"
-                },
                 "trace": {
                     "type": [
                         "null",
@@ -37,6 +30,13 @@
                 "enabled"
             ],
             "properties": {
+                "backend": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "pattern": "^(kernel|bpf)$"
+                },
                 "daemonset": {
                     "type": "object",
                     "required": [

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -6,6 +6,9 @@ node:
   # When enabled, Helm chart deploys the Falcon Sensors to Kubernetes nodes
   enabled: true
 
+  # Overrides the backend leveraged by the Falcon Sensor (kernel, bpf)
+  backend: kernel
+
   daemonset:
     # Annotations to apply to the daemonset
     annotations: {}
@@ -208,7 +211,6 @@ falcon:
   app:
   trace: none
   feature:
-  backend: kernel
   message_log:
   billing:
   tags:


### PR DESCRIPTION
Relates to https://github.com/CrowdStrike/falcon-operator/pull/332

The current behavior of this chart is to generate the FALCONCTL_OPT_BACKEND environment variable (via configmap) when falcon.backend is set (as it is, by default), regardless of whether the node or container sensor is being deployed.
This variable and corresponding command argument causes a fatal error in version 6.51+ of the container sensor.