### PR TITLE
Enable setting maxUnavailable as percentage

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.18.5
+version: 1.18.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.18.5
+appVersion: 1.18.6
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -70,9 +70,18 @@
                             "pattern": "^(RollingUpdate|OnDelete)$"
                         },
                         "maxUnavailable": {
-                            "type": "integer",
-                            "default": "1",
-                            "pattern": "^[0-9]+$"
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "default": "10%",
+                                    "pattern": "^[0-9]+%$"
+                                },
+                                {
+                                    "type": "integer",
+                                    "default": "1",
+                                    "pattern": "^[0-9]+$"
+                                }
+                            ]
                         },
                         "serviceAccountName": {
                             "type": "object",


### PR DESCRIPTION
This PR enables setting maxUnavailable as percentage.
[DaemonSetSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec) clearly defines the  maxUnavailable field as IntOrString