### PR TITLE
fix: throw validation error if falcon.backend is set

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.18.3
+version: 1.18.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.18.3
+appVersion: 1.18.4
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -21,6 +21,9 @@
                         "string"
                     ],
                     "pattern": "^(|none|err|warn|info|debug)$"
+                },
+                "backend": {
+                    "type": "null"
                 }
             }
         },


### PR DESCRIPTION
Internal request was raised to throw an error if falcon.backend is set, so that customers can identify the change earlier and adjust to node.backend.