### PR TITLE
fix: supported distros in README

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.19.0
+version: 1.19.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.19.0
+appVersion: 1.19.1
 
 keywords:
   - CrowdStrike
@@ -41,4 +41,4 @@ maintainers:
     email: integrations@crowdstrike.com
 
 icon: https://raw.githubusercontent.com/CrowdStrike/falcon-helm/main/images/crowdstrike-logo.svg
-kubeVersion: ">1.15.0-0"
+kubeVersion: ">1.22.0-0"

--- a/helm-charts/falcon-sensor/README.md
+++ b/helm-charts/falcon-sensor/README.md
@@ -13,9 +13,8 @@ The Falcon Helm chart has been tested to deploy on the following Kubernetes dist
   * Daemonset (node) sensor supprt for EKS nodes
   * Container sensor support for EKS Fargate nodes
 * Azure Kubernetes Service (AKS)
-* Google Kubernetes Engine (GKE) - DaemonSet support for Ubuntu nodes only, Container sensor for GCOS nodes.
+* Google Kubernetes Engine (GKE)
 * Rancher K3s
-* Red Hat OpenShift Container Platform 4.6+
 
 # Dependencies
 


### PR DESCRIPTION
- GCOS is now supported as a node type for GKE deployments
- OpenShift support is now deprecated as OpenShift users should use the certified operator to maintain support with Red Hat