### PR TITLE
Allow flexible configuration of container affinity

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.19.1
+version: 1.19.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/falcon-sensor/README.md
+++ b/helm-charts/falcon-sensor/README.md
@@ -5,7 +5,7 @@ platform purpose-built to stop breaches via a unified set of cloud-delivered
 technologies that prevent all types of attacks — including malware and much
 more.
 
-# Kubernetes Cluster Compatability
+# Kubernetes Cluster Compatibility
 
 The Falcon Helm chart has been tested to deploy on the following Kubernetes distributions:
 

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -83,21 +83,10 @@ spec:
         {{- end }}
     {{- end }}
     spec:
+      {{- if .Values.container.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: DoesNotExist
+        {{- toYaml .Values.container.affinity | nindent 6 }}
+      {{- end }}
       {{- if .Values.container.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml .Values.container.topologySpreadConstraints | nindent 6 }}

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -95,6 +95,23 @@ container:
       matchLabels:
         crowdstrike.com/component: crowdstrike-falcon-injector
 
+  # Configure affinity to restrict container to certain nodes
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/os
+            operator: In
+            values:
+            - linux
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: DoesNotExist
+
   # Auto update the certificates every time there is an update
   autoCertificateUpdate: true
 


### PR DESCRIPTION
Allow more flexible configuration of the container affinity. This change allows for better support of mixed scenarios where the regular worker nodes are protected by the node sensor and only certain containers should be protected by the container sensor, e.g. when using AWS Fargate, Azure Container Instances, Google Cloud Run. Resolves #134 