### PR TITLE
fixing cleaning issue when using registryConfigJSON

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.20.1
+version: 1.20.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.20.1
+appVersion: 1.20.2
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -63,7 +63,7 @@ spec:
         - name: {{ .Values.node.image.pullSecrets }}
       {{- end }}
       {{- if .Values.node.image.registryConfigJSON }}
-        - name: {{ include "falcon-sensor.fullname" . }}-pull-secret
+        - name: {{ include "falcon-sensor.fullname" . }}-pull-secret-cleanup
       {{- end }}
     {{- end }}
     {{- end }}

--- a/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.node.enabled }}
+{{- if .Values.node.image.registryConfigJSON }}
+{{- $registry := .Values.node.image.registryConfigJSON }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falcon-sensor.fullname" . }}-pull-secret-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+data:
+  .dockerconfigjson: {{ $registry }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Fixing the issue by adding a dedicated pull-secret for the post-delete helm's hook.

When the cleanup daemonset is deployed, the pod can't be deployed due to the pull secret already deleted by helm (we are in the post-delete stage at that time).

```
daemonset/falcon-helm-falcon-sensor-node-cleanup   Created pod: falcon-helm-falcon-sensor-node-cleanup-tckrc
pod/falcon-helm-falcon-sensor-node-cleanup-tckrc   Successfully assigned falcon-system/falcon-helm-falcon-sensor-node-cleanup-tckrc to workernode
daemonset/falcon-helm-falcon-sensor-node-cleanup   Created pod: falcon-helm-falcon-sensor-node-cleanup-t6blh
pod/falcon-helm-falcon-sensor-node-cleanup-t6blh   Successfully assigned falcon-system/falcon-helm-falcon-sensor-node-cleanup-t6blh to workernode
pod/falcon-helm-falcon-sensor-node-cleanup-tckrc   Pulling image "registry...../falcon-sensor:daemonset-tag"
pod/falcon-helm-falcon-sensor-node-cleanup-t6blh   Pulling image "registry...../falcon-sensor:daemonset-tag"
pod/falcon-helm-falcon-sensor-node-cleanup-tckrc   Failed to pull image "registry...../falcon-sensor:daemonset-tag": rpc error: code = Unknown desc = failed to pull and unpack image "registry...../falcon-sensor:daemonset-tag": failed to resolve reference "registry...../falcon-sensor:daemonset-tag": failed to authorize: failed to fetch anonymous token: unexpected status: 401
pod/falcon-helm-falcon-sensor-node-cleanup-tckrc   Error: ErrImagePull
pod/falcon-helm-falcon-sensor-node-cleanup-t6blh   Failed to pull image "registry...../falcon-sensor:daemonset-tag": rpc error: code = Unknown desc = failed to pull and unpack image "registry...../falcon-sensor:daemonset-tag": failed to resolve reference "registry...../falcon-sensor:daemonset-tag": failed to authorize: failed to fetch anonymous token: unexpected status: 401
pod/falcon-helm-falcon-sensor-node-cleanup-t6blh   Error: ErrImagePull
```