### PR TITLE
Fix: sensor: APD ConfigMap value is missing when false

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.20.2
+version: 1.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.20.2
+appVersion: 1.21.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.21.0
+version: 1.20.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.21.0
+appVersion: 1.20.3
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
   {{- range $key, $value := .Values.falcon }}
-  {{- if and ($value) (ne $key "cid") }}
+  {{- if and (or $value (eq $value false)) (ne $key "cid") }}
   FALCONCTL_OPT_{{ $key | upper }}: {{ $value | quote }}
   {{- end }}
   {{- end }}

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
   {{- range $key, $value := .Values.falcon }}
-  {{- if and (or $value (eq $value false)) (ne $key "cid") }}
+  {{- if and (or $value (eq ($value | toString) "false")) (ne $key "cid") }}
   FALCONCTL_OPT_{{ $key | upper }}: {{ $value | quote }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Creating the `falcon-sensor` with the following configuration mangles the proxy settings:
```yaml
falcon:
  cid: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AA
  apd: false
  aph: hostname
  app: 1234
```

Resulting ConfigMap values:
```yaml
data:
  FALCONCTL_OPT_CID: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AA
  FALCONCTL_OPT_APH: "hostname"
  FALCONCTL_OPT_APP: "1234"
  FALCONCTL_OPT_TRACE: "none"
  FALCONCTL_OPT_BACKEND: "kernel"
```

After this fix:
```yaml
data:
  FALCONCTL_OPT_CID: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-AA
  FALCONCTL_OPT_APD: "false"
  FALCONCTL_OPT_APH: "hostname"
  FALCONCTL_OPT_APP: "1234"
  FALCONCTL_OPT_TRACE: "none"
  FALCONCTL_OPT_BACKEND: "kernel"
```

APD needs to be "false" when enabling the proxy (disable = false, so enable), so this value is _only_ needed when it's false.

The admission controller helm chart has similar configurations, but the proxy settings are configured as strings, so this boolean check is fine there.