### PR TITLE
Remove AGENT_CLIENT_ID from the KPA configmap

### DIFF
--- a/helm-charts/cs-k8s-protection-agent/Chart.yaml
+++ b/helm-charts/cs-k8s-protection-agent/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1474.1"
+version: "0.1474.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1474.1"
+appVersion: "0.1474.2"
 
 icon: "https://www.crowdstrike.com/wp-content/uploads/2020/08/FalconPremium@2x.svg"

--- a/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
+++ b/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
@@ -7,6 +7,5 @@ metadata:
 data:
   AGENT_CLUSTER_NAME: {{ .Values.crowdstrikeConfig.clusterName | quote }}
   AGENT_DEBUG: {{ .Values.crowdstrikeConfig.enableDebug | default "false" | quote }}
-  AGENT_CLIENT_ID: {{ .Values.crowdstrikeConfig.clientID | quote }}
   AGENT_ENV: {{ .Values.crowdstrikeConfig.env | quote }}
   AGENT_HELM_VERSION: {{ .Chart.Version | quote }}


### PR DESCRIPTION
The `AGENT_CLIENT_ID` and `AGENT_CLIENT_SECRET` are used to create a secret object, which in turn are set as environmental variables for the container by referencing the secret. There is no need to set the `AGENT_CLIENT_ID` environmental variable by adding it again to the configmap.

