### PR TITLE
fix: allow updating in place from k8s 1.24 to 1.25 by optionally disabling PSPs

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.20.4
+version: 1.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.20.4
+appVersion: 1.21.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/container_psp.yaml
+++ b/helm-charts/falcon-sensor/templates/container_psp.yaml
@@ -1,6 +1,6 @@
 {{- if lt (int (semver .Capabilities.KubeVersion.Version).Minor) 25 }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
-{{- if .Values.container.enabled }}
+{{- if and .Values.container.enabled .Values.container.psp.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm-charts/falcon-sensor/templates/node_psp.yaml
+++ b/helm-charts/falcon-sensor/templates/node_psp.yaml
@@ -1,6 +1,6 @@
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if lt (int (semver .Capabilities.KubeVersion.Version).Minor) 25 }}
-{{- if .Values.node.enabled }}
+{{- if and .Values.node.enabled .Values.node.psp.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -79,6 +79,10 @@ node:
   # How long to wait for Falcon pods to stop gracefully
   terminationGracePeriod: 30
 
+  #When enabled, Helm Chart installs a PodSecurityPolicy for the node sensor
+  psp:
+    enabled: true
+
 container:
   # When enabled, Helm chart deploys the Falcon Container Sensor to Pods through Webhooks
   enabled: false
@@ -204,6 +208,10 @@ container:
     requests:
       cpu: 10m
       memory: 20Mi
+  
+    #When enabled, Helm Chart installs a PodSecurityPolicy for the container sensor
+  psp:
+    enabled: true
 
 serviceAccount:
   name: crowdstrike-falcon-sa


### PR DESCRIPTION
fixes: #215 

Allow the node and container PodSecurityPolicy manifests to be disabled.

If a user has already installed falcon-sensor on a cluster on 1.24, they can use these values to disable the PSPs _prior_ to attempting the upgrade to 1.25. This allows the 1.25 upgrade to proceed cleanly without having to manually patch the PSPs out of the Chart's release secret. 

![image](https://github.com/CrowdStrike/falcon-helm/assets/47261237/7e6be1e9-84e0-45ef-8528-eab06ea405bb)
