### PR TITLE
fix(falcon-sensor): allow for preexisting PriorityClass

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.21.1
+version: 1.21.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.21.1
+appVersion: 1.21.2
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/node_priorityclass.yaml
+++ b/helm-charts/falcon-sensor/templates/node_priorityclass.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.node.enabled }}
-{{- if or .Values.node.daemonset.priorityClassName .Values.node.gke.autopilot }}
+{{- if and .Values.node.daemonset.priorityClassCreate (or .Values.node.daemonset.priorityClassName .Values.node.gke.autopilot) }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -70,6 +70,10 @@
                         "nodeAffinity": {
                             "type": "object"
                         },
+                        "priorityClassCreate": {
+                            "type": "boolean",
+                            "default": "true"
+                        },
                         "priorityClassName": {
                             "type": "string"
                         },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -24,6 +24,7 @@ node:
     labels: {}
 
     # Assign a PriorityClassName to pods if set
+    priorityClassCreate: true #Whether or not to create a PriorityClass as part of this Chart
     priorityClassName: ""
     priorityClassValue: 1000000000
 

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -23,8 +23,9 @@ node:
     # additionals labels
     labels: {}
 
+    # Enable the priorityClass creation on chart installation
+    priorityClassCreate: true
     # Assign a PriorityClassName to pods if set
-    priorityClassCreate: true #Whether or not to create a PriorityClass as part of this Chart
     priorityClassName: ""
     priorityClassValue: 1000000000
 


### PR DESCRIPTION
fixes: #230 

Allows for the user to specify a preexisting PriorityClass by opting out of the creation of one in this Chart.