### PR TITLE
KPA: Apply clientID validation logic only when existingSecret is empty

### DIFF
--- a/helm-charts/cs-k8s-protection-agent/Chart.yaml
+++ b/helm-charts/cs-k8s-protection-agent/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1474.2"
+version: "0.1474.3"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1474.2"
+appVersion: "0.1474.3"
 
 icon: "https://www.crowdstrike.com/wp-content/uploads/2020/08/FalconPremium@2x.svg"

--- a/helm-charts/cs-k8s-protection-agent/values.schema.json
+++ b/helm-charts/cs-k8s-protection-agent/values.schema.json
@@ -124,8 +124,7 @@
                     "type": "string"
                 },
                 "clientID": {
-                    "type": "string",
-                    "pattern": "^[a-fA-F0-9]{32}$"
+                    "type": "string"
                 },
                 "clientSecret": {
                     "type": "string"
@@ -160,6 +159,9 @@
             },
             "then": {
                 "properties": {
+                    "clientID": {
+                        "pattern": "^[a-fA-F0-9]{32}$"
+                    },
                     "clientSecret": {
                         "pattern": "^[a-zA-Z0-9]{40}$"
                     }


### PR DESCRIPTION
Apply clientID validation logic only when existingSecret is empty. We are using an `existingSecret` and not hardcoding the `clientID` and `clientSecret` in `values.yaml`. Right now, `clientID` validation is performed even if the `existingSecret` is defined. As a result, this is breaking our deployment.