### PR TITLE
Feat/kpa proxy support

### DIFF
--- a/helm-charts/cs-k8s-protection-agent/Chart.yaml
+++ b/helm-charts/cs-k8s-protection-agent/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1474.3"
+version: "0.1474.4"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1474.3"
+appVersion: "0.1474.0"
 
 icon: "https://www.crowdstrike.com/wp-content/uploads/2020/08/FalconPremium@2x.svg"

--- a/helm-charts/cs-k8s-protection-agent/README.md
+++ b/helm-charts/cs-k8s-protection-agent/README.md
@@ -158,6 +158,32 @@ When external cluster communication is routed through a proxy server, the follow
 
 ### Enable a proxy configuration for the Kubernetes Protection Agent
 
+#### Enabling proxy support at install time
+
+#####  Using set commands to specify `proxyConfig` values
+* Example using set commands - special characters need to be escaped
+    ```
+    helm upgrade --install kpagent crowdstrike/cs-k8s-protection-agent \
+    -n falcon-kubernetes-protection --create-namespace -f values.yaml \
+    --set proxyConfig.HTTP_PROXY="http:\/\/100.10.10.10:8080" \
+    --set proxyConfig.HTTPS_PROXY="http:\/\/100.10.10.10:8080" \
+    --set proxyConfig.NO_PROXY="localhost\,10.0.0.0\/8"
+    ```
+
+##### Adding to values file
+* Example appending proxy values to the values file
+```
+crowdstrikeConfig:
+  ...
+  ...
+proxyConfig:
+  HTTP_PROXY: http://100.10.10.10:8080
+  HTTP_PROXY: http://100.10.10.10:8080
+  NO_PROXY: localhost,10.0.0.0/8
+```
+
+#### Manually modifying an existing install
+
 If a proxy configuration is required for the KPA, follow these steps to enable proxy server support.
 
 1.  Install the KPA using the Helm chart following the specific Kubernetes service instructions.

--- a/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
+++ b/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
@@ -9,14 +9,7 @@ data:
   AGENT_DEBUG: {{ .Values.crowdstrikeConfig.enableDebug | default "false" | quote }}
   AGENT_ENV: {{ .Values.crowdstrikeConfig.env | quote }}
   AGENT_HELM_VERSION: {{ .Chart.Version | quote }}
-  {{- if .Values.proxyConfig }}
-  {{- if .Values.proxyConfig.HTTP_PROXY }}
-  HTTP_PROXY: {{ .Values.proxyConfig.HTTP_PROXY }}
-  {{- end }}
-  {{- if .Values.proxyConfig.HTTPS_PROXY }}
-  HTTPS_PROXY: {{ .Values.proxyConfig.HTTPS_PROXY }}
-  {{- end }}
-  {{- if .Values.proxyConfig.NO_PROXY }}
-  NO_PROXY: {{ .Values.proxyConfig.NO_PROXY }}
-  {{- end }}
-  {{- end }}
+  HTTP_PROXY: {{ .Values.proxyConfig.HTTP_PROXY | default "" }}
+  HTTPS_PROXY: {{ .Values.proxyConfig.HTTPS_PROXY | default "" }}
+  NO_PROXY: {{ .Values.proxyConfig.NO_PROXY | default "" }}
+

--- a/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
+++ b/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
@@ -9,3 +9,14 @@ data:
   AGENT_DEBUG: {{ .Values.crowdstrikeConfig.enableDebug | default "false" | quote }}
   AGENT_ENV: {{ .Values.crowdstrikeConfig.env | quote }}
   AGENT_HELM_VERSION: {{ .Chart.Version | quote }}
+  {{- if .Values.proxyConfig }}
+  {{- if .Values.proxyConfig.HTTP_PROXY }}
+  HTTP_PROXY: {{ .Values.proxyConfig.HTTP_PROXY }}
+  {{- end }}
+  {{- if .Values.proxyConfig.HTTPS_PROXY }}
+  HTTPS_PROXY: {{ .Values.proxyConfig.HTTPS_PROXY }}
+  {{- end }}
+  {{- if .Values.proxyConfig.NO_PROXY }}
+  NO_PROXY: {{ .Values.proxyConfig.NO_PROXY }}
+  {{- end }}
+  {{- end }}

--- a/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
+++ b/helm-charts/cs-k8s-protection-agent/templates/configmap.yaml
@@ -9,7 +9,13 @@ data:
   AGENT_DEBUG: {{ .Values.crowdstrikeConfig.enableDebug | default "false" | quote }}
   AGENT_ENV: {{ .Values.crowdstrikeConfig.env | quote }}
   AGENT_HELM_VERSION: {{ .Chart.Version | quote }}
-  HTTP_PROXY: {{ .Values.proxyConfig.HTTP_PROXY | default "" }}
-  HTTPS_PROXY: {{ .Values.proxyConfig.HTTPS_PROXY | default "" }}
-  NO_PROXY: {{ .Values.proxyConfig.NO_PROXY | default "" }}
+  {{- if .Values.proxyConfig.HTTP_PROXY }}
+  HTTP_PROXY: {{ .Values.proxyConfig.HTTP_PROXY }}
+  {{- end }}
+  {{- if .Values.proxyConfig.HTTPS_PROXY }}
+  HTTPS_PROXY: {{ .Values.proxyConfig.HTTPS_PROXY }}
+  {{- end }}
+  {{- if .Values.proxyConfig.NO_PROXY }}
+  NO_PROXY: {{ .Values.proxyConfig.NO_PROXY }}
+  {{- end }}
 

--- a/helm-charts/cs-k8s-protection-agent/values.schema.json
+++ b/helm-charts/cs-k8s-protection-agent/values.schema.json
@@ -167,6 +167,30 @@
                     }
                 }
             }
+        },
+        "proxyConfig": {
+            "default": {},
+            "type": "object",
+            "properties": {
+                "HTTP_PROXY": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "HTTPS_PROXY": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "NO_PROXY": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            }
         }
     }
 }

--- a/helm-charts/cs-k8s-protection-agent/values.yaml
+++ b/helm-charts/cs-k8s-protection-agent/values.yaml
@@ -51,3 +51,5 @@ crowdstrikeConfig:
   cid: ""
   dockerAPIToken: ""
   existingSecret: ""
+
+proxyConfig: {}

--- a/helm-charts/cs-k8s-protection-agent/values.yaml
+++ b/helm-charts/cs-k8s-protection-agent/values.yaml
@@ -52,4 +52,7 @@ crowdstrikeConfig:
   dockerAPIToken: ""
   existingSecret: ""
 
-proxyConfig: {}
+proxyConfig:
+  HTTP_PROXY: ""
+  HTTPS_PROXY: ""
+  NO_PROXY: ""


### PR DESCRIPTION
This PR for the KPA chart adds the following:

- Enables setting the HTTP_PROXY, HTTPS_PROXY & NO_PROXY settings at install time
- Increments chart version
- Resets app version back to .0 increment as this version represents when new images are available and should not have been incremented during the previous merges

