### PR TITLE
Parameterise the hard limit on pods in ResourceQuota object

### DIFF
--- a/helm-charts/falcon-kac/Chart.yaml
+++ b/helm-charts/falcon-kac/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.7
+appVersion: 1.0.8
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-kac/templates/resourcequota.yaml
+++ b/helm-charts/falcon-kac/templates/resourcequota.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "falcon-kac.labels" . | nindent 4 }}
 spec:
   hard:
-    pods: 2
+    pods: {{ .Values.resourceQuota.pods }}
   scopeSelector:
     matchExpressions:
     - operator: In

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -259,6 +259,32 @@
                     ]
                 }
             }
+        },
+        "resourceQuota": {
+            "type": "object",
+            "properties": {
+                "pods": {
+                    "oneOf": [
+                        {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": "2",
+                            "pattern": "^[0-9]+$"
+                        },
+                        {
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": "2",
+                            "pattern": "^[0-9]+$",
+                            "minimum": 1
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -94,3 +94,7 @@ webhook:
   failurePolicy: Ignore
   # Comma sparated list of namespaces in which we need to disable validation e.g test1,test2
   disableNamespaces:
+
+# Number of pods for resourceQuota object
+resourceQuota:
+  pods: 2


### PR DESCRIPTION
Hi team,

I want to parameterise `spec.hard.pods` in `ResourceQuota` object. This is useful when falcon-kac is deployed on to namespace where there are existing deployments that take up pods quota with `PriorityClass=system-cluster-critical` ( for example: api-server in kube-system namespace

Fixes: https://github.com/CrowdStrike/falcon-helm/issues/241