### PR TITLE
add read permissions for resources that are monitored by KAC

### DIFF
--- a/helm-charts/falcon-kac/Chart.yaml
+++ b/helm-charts/falcon-kac/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.5
+appVersion: 1.0.6
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-kac/templates/clusterrole.yaml
+++ b/helm-charts/falcon-kac/templates/clusterrole.yaml
@@ -10,6 +10,9 @@ rules:
   resources:
   - namespaces
   - nodes
+  - pods
+  - replicationcontrollers
+  - services
   verbs:
   - get
   - list
@@ -19,6 +22,25 @@ rules:
   resources:
   - daemonsets
   - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
   verbs:
   - get
   - list


### PR DESCRIPTION
For dry-run mode, falcon-kac needs read permissions on the resources it validates as admission controller webhook