### PR TITLE
falcon-helm: Update initContainer args

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.1
+version: 1.24.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.24.1
+appVersion: 1.24.2
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -103,7 +103,7 @@ spec:
             echo "Running /opt/CrowdStrike/falcon-daemonset-init -i";
             /opt/CrowdStrike/falcon-daemonset-init -i
         {{- else }}
-        args: ['-c', 'if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -i" ; /opt/CrowdStrike/falcon-daemonset-init -i ; else if [ -d "/host_opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /host_opt/CrowdStrike/falconstore; fi; mkdir -p /host_opt/CrowdStrike && touch /host_opt/CrowdStrike/falconstore; fi']
+        args: ['-c', 'if [ -x "/host_opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -i" ; /host_opt/CrowdStrike/falcon-daemonset-init -i ; else if [ -d "/host_opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /host_opt/CrowdStrike/falconstore; fi; mkdir -p /host_opt/CrowdStrike && touch /host_opt/CrowdStrike/falconstore; fi']
         volumeMounts:
           - name: falconstore-dir
             mountPath: /host_opt


### PR DESCRIPTION
The arguments in the initContainer check if the executable file `/opt/CrowdStrike/falcon-daemonset-init` exists. Since the hostPath volume `falconstore-dir` is mounted to `/host_opt`, this file is not visible inside the initContainer, and the check always fails. I assume this is the helper binary to initialize `falconstore`?

The mountPath change from `/opt` to `host_opt` was introduced in this [commit](https://github.com/CrowdStrike/falcon-helm/commit/1fff4b642babf31000f5240da003cb193c07192c)