### PR TITLE
fix(kpa): update regsecret's name when registryConfigJSON is used

### DIFF
--- a/helm-charts/cs-k8s-protection-agent/Chart.yaml
+++ b/helm-charts/cs-k8s-protection-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.0.1"
+version: "1.0.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/cs-k8s-protection-agent/templates/deployment.yaml
+++ b/helm-charts/cs-k8s-protection-agent/templates/deployment.yaml
@@ -22,14 +22,15 @@ spec:
     spec:
     {{- if or (.Values.image.pullSecrets) (.Values.image.registryConfigJSON) (.Values.crowdstrikeConfig.dockerAPIToken) }}
       imagePullSecrets:
-        {{ if .Values.crowdstrikeConfig.dockerAPIToken }}
+        {{- if and (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
+          {{- fail "crowdstrikeConfig.dockerAPIToken and image.registryConfigJSON cannot be used together." }}
+        {{- else -}}
+        {{ if or (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
         - name: {{ include "cs-k8s-protection-agent.fullname" . }}-regsecret
+        {{- end }}
         {{- end }}
         {{ if .Values.image.pullSecrets }}
         - name: {{ .Values.image.pullSecrets }}
-        {{- end }}
-        {{ if .Values.image.registryConfigJSON }}
-        - name: {{ include "cs-k8s-protection-agent.fullname" . }}-regsecret-registryconfigjson
         {{- end }}
     {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name | default ( include "cs-k8s-protection-agent.fullname" . ) }}

--- a/helm-charts/cs-k8s-protection-agent/templates/docker-secret.yaml
+++ b/helm-charts/cs-k8s-protection-agent/templates/docker-secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.crowdstrikeConfig.dockerAPIToken }}
+{{ if or (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,18 +8,10 @@ metadata:
   {{- include "cs-k8s-protection-agent.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
+{{- if .Values.crowdstrikeConfig.dockerAPIToken }}
   .dockerconfigjson: {{ template "imagePullSecret" . }}
-{{- end}}
-{{- if .Values.image.registryConfigJSON }}
-{{- $registry := .Values.image.registryConfigJSON }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "cs-k8s-protection-agent.fullname" . }}-regsecret
-  namespace: {{ .Release.Namespace }}
-  labels:
-  {{- include "cs-k8s-protection-agent.labels" . | nindent 4 }}
-data:
-  .dockerconfigjson: {{ $registry }}
-type: kubernetes.io/dockerconfigjson
 {{- end }}
+{{- if .Values.image.registryConfigJSON }}
+  .dockerconfigjson: {{ .Values.image.registryConfigJSON }}
+{{- end }}
+{{- end}}


### PR DESCRIPTION
in deployment.yaml line 32 : the secret name should end with `-registryconfigjson`

```
- name: {{ include "cs-k8s-protection-agent.fullname" . }}-regsecret-registryconfigjson
```

This is fixing the secret name