### PR TITLE
feat: set securityContext for deployments

### DIFF
--- a/helm-charts/falcon-image-analyzer/Chart.yaml
+++ b/helm-charts/falcon-image-analyzer/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.3"
+appVersion: "1.0.11"

--- a/helm-charts/falcon-image-analyzer/README.md
+++ b/helm-charts/falcon-image-analyzer/README.md
@@ -15,8 +15,9 @@ The Falcon Image Analyzer Helm chart has been tested to deploy on the following 
 * SUSE Rancher K3s
 * Red Hat OpenShift Kubernetes
 
-## New updates in current release (1.1.3)
-- Adding support to exclude registries / namespaces / pods via Helm or spec . Image Support `1.0.8`
+## New updates in current release (1.1.5)
+- Adding a way to specify `priorityClassName` for pod. Image Support `1.0.11`
+- Configure securityContexts for deployments. Image Support requires version `1.0.11`
 
 ## Dependencies
 
@@ -46,6 +47,7 @@ The following tables list the Falcon sensor configurable parameters and their de
 |:---------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
 | `deployment.enabled`   required                                                                                            | Set to `true` if running in Watcher Mode i.e.                                                                                                                  | false                                                                                  |
 | `daemsonset.enabled`     required                                                                                          | Set to `true` if running in Socket Mode i.e. Both CANNOT be true . This  causes the IAR to run in `socket` mode                                                | false                                                                                  |
+| `priorityClassName`                  optional    ( available in falcon-imageanalyzer Helm Chart >= 1.1.4)                  | Set to `system-node-critical` or `system-cluster-critical` to avoid pod evictions due to resource limits.                                                      | ""                                                                                     |
 | `privateRegistries.credentials`  optional                                                                                  | Use this param to provide the comma separated registry secrets of the form namsepace1:secretname1,namespace:secret2                                            | ""                                                                                     |
 | `image.repo`       required                                                                                                | IAR image repo name                                                                                                                                            | `[CROWDSTREIKE_IMAGE_REGISTRY]/falcon-imageanalyzer/us-1/release/falcon-imageanalyzer` |
 | `image.tag`        required                                                                                                | Image tag version                                                                                                                                              | None                                                                                   |
@@ -319,6 +321,10 @@ for e.g.  a docker-registry secret can be created as below
 
 ```
 use the above secret as `"my-app-ns:regcred,my-app-ns:regcred2"`
+
+### Pod Eviction
+If for some reason pod evivictions are observed in the Cluster due to exceeding ephemeral storage
+please set the `priorityClassName`  to `system-node-critical` or `system-cluster-critical` in `config-values.yaml` and update.
 
 ### Exclusions ( available in falcon-imageanalyzer v >= 1.0.8 and Helm Chart v >= 1.1.3)
 In order to exclude pods from scans, you can either exclude the registries, namespace, or specific pods

--- a/helm-charts/falcon-image-analyzer/ci/cid-values.yaml
+++ b/helm-charts/falcon-image-analyzer/ci/cid-values.yaml
@@ -1,3 +1,5 @@
+deployment:
+  enabled: true
 crowdstrikeConfig:
   clusterName: "test-cluster12.test"
   clientID: "abcdefABCDEF0123456789abcdefABCD"

--- a/helm-charts/falcon-image-analyzer/templates/daemonset.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/daemonset.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        sensor.falcon-system.crowdstrike.com/injection: disabled
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm-charts/falcon-image-analyzer/templates/deployment.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/deployment.yaml
@@ -54,12 +54,21 @@ spec:
             runAsUser: 0
             runAsNonRoot: false
             privileged: false
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             runAsUser: 0
             privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           resources:
           {{- if .Values.resources }}
           {{- toYaml .Values.resources | nindent 12 }}

--- a/helm-charts/falcon-image-analyzer/templates/deployment.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       annotations:
+        sensor.falcon-system.crowdstrike.com/injection: disabled
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm-charts/falcon-image-analyzer/values.schema.json
+++ b/helm-charts/falcon-image-analyzer/values.schema.json
@@ -249,6 +249,44 @@
             }
         }
     },
+    "oneOf": [
+        {
+            "properties": {
+                "deployment": {
+                    "properties": {
+                        "enabled": {
+                            "const": true
+                        }
+                    }
+                }
+            },
+            "additionalProperties": {
+                "properties": {
+                    "enabled": {
+                        "const": false
+                    }
+                }
+            }
+        },
+        {
+            "properties": {
+                "daemonset": {
+                    "properties": {
+                        "enabled": {
+                            "const": true
+                        }
+                    }
+                }
+            },
+            "additionalProperties": {
+                "properties": {
+                    "enabled": {
+                        "const": false
+                    }
+                }
+            }
+        }
+    ],
     "allOf": [
         {
             "if": {

--- a/helm-charts/falcon-image-analyzer/values.yaml
+++ b/helm-charts/falcon-image-analyzer/values.yaml
@@ -11,7 +11,6 @@ daemonset:
 deployment:
   enabled: false
 
-
 # Do not override anywhere in values - Always 1 for Deployment. NA for daemonset
 replicaCount: 1
 image:
@@ -63,7 +62,19 @@ resources: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/os
+          operator: In
+          values:
+            - linux
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+            - amd64
 
 priorityClassName: ""
 
@@ -134,7 +145,6 @@ crowdstrikeConfig:
   # /entities/image-registry-credentials/v1
   dockerAPIToken: ""
 
-
   # Use this value if you have an existing secret
   # defined in your k8s that may contain secrets
   # for falcon api client id and pw
@@ -143,7 +153,6 @@ crowdstrikeConfig:
   agentRuntime: ""
   agentRuntimeSocket: ""
   agentMaxConsumerThreads: "1"
-
 
 proxyConfig:
   HTTP_PROXY: ""


### PR DESCRIPTION
- Require either daemonset or deployment to be enabled
- Disable sidecar injection
- Set default affinity settings