### PR TITLE
Default priorityClassCreate to false

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.25.2
+version: 1.25.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.25.2
+appVersion: 1.25.3
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -72,7 +72,7 @@
                         },
                         "priorityClassCreate": {
                             "type": "boolean",
-                            "default": "true"
+                            "default": "false"
                         },
                         "priorityClassName": {
                             "type": "string"

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -24,7 +24,7 @@ node:
     labels: {}
 
     # Enable the priorityClass creation on chart installation
-    priorityClassCreate: true
+    priorityClassCreate: false
     # Assign a PriorityClassName to pods if set
     priorityClassName: ""
     priorityClassValue: 1000000000


### PR DESCRIPTION
If a user removes `priorityClassCreate` from the values file entirely, the default action should not be to attempt to create a priorityClass of a given `priorityClassName`.  

In my opinion/experience, if the user is using the default helm values file as a guide and has indicated the name of a priority-class to use but has deleted the directive to create a priority class by that name, the intended action is to *not* try to create that priority-class.  