### PR TITLE
Allow setting nodeSelector and affinity for falcon-kac

### DIFF
--- a/helm-charts/falcon-kac/Chart.yaml
+++ b/helm-charts/falcon-kac/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.8
+appVersion: 1.1.1
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -206,10 +206,8 @@ spec:
           name: crowdstrike-falcon-vol0
         - mountPath: /var/private/
           name: crowdstrike-falcon-vol1
-      {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       securityContext:
         seccompProfile:

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -206,19 +206,23 @@ spec:
           name: crowdstrike-falcon-vol0
         - mountPath: /var/private/
           name: crowdstrike-falcon-vol1
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        kubernetes.io/os: linux
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       priorityClassName: system-cluster-critical
       securityContext:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ .Values.serviceAccount.name }}
       shareProcessNamespace: true
-      {{- if .Values.tolerations }}
-      tolerations:
-      {{- with .Values.tolerations }}
-      {{- toYaml . | nindent 6 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
       - name: {{ include "falcon-kac.name" . }}-tls-certs

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -167,12 +167,23 @@
             "type": "object",
             "default": {}
         },
+        "nodeSelector": {
+            "type": "object",
+            "default": {
+                "kubernetes.io/os": "linux",
+                "kubernetes.io/arch": "amd64"
+            }
+        },
         "podAnnotations": {
             "type": "object",
             "default": {}
         },
         "tolerations": {
             "type": "array"
+        },
+        "affinity": {
+            "type": "object",
+            "default": {}
         },
         "falconClientResources": {
             "type": "object",

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -167,13 +167,6 @@
             "type": "object",
             "default": {}
         },
-        "nodeSelector": {
-            "type": "object",
-            "default": {
-                "kubernetes.io/os": "linux",
-                "kubernetes.io/arch": "amd64"
-            }
-        },
         "podAnnotations": {
             "type": "object",
             "default": {}
@@ -183,7 +176,25 @@
         },
         "affinity": {
             "type": "object",
-            "default": {}
+            "default": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "kubernetes.io/arch",
+                                        "operator": "In",
+                                        "values": [
+                                            "amd64"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
         },
         "falconClientResources": {
             "type": "object",

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -65,7 +65,13 @@ labels: {}
 # Annotations to apply to the webhook deployment
 podAnnotations: {}
 
+nodeSelector:
+  kubernetes.io/os: linux
+  kubernetes.io/arch: amd64
+
 tolerations: []
+
+affinity: {}
 
 falconClientResources:
   limits:

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -65,13 +65,17 @@ labels: {}
 # Annotations to apply to the webhook deployment
 podAnnotations: {}
 
-nodeSelector:
-  kubernetes.io/os: linux
-  kubernetes.io/arch: amd64
-
 tolerations: []
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
 
 falconClientResources:
   limits:


### PR DESCRIPTION
This will allow falcon-kac to be used on multi-arch clusters, as long as there is a amd64 node available.

I've tested this is working on a fresh EKS cluster with Karpenter - it brought up a c7i.large instance alongside the m7g.large instances that were there already