### PR TITLE
Add support to falcon-sensor for existing secret in addition to configmap

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.26.1
+version: 1.26.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.26.1
+appVersion: 1.26.2
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/README.md
+++ b/helm-charts/falcon-sensor/README.md
@@ -129,6 +129,7 @@ The following tables lists the more common configurable parameters of the chart 
 | `node.image.pullSecrets`          | Pull secrets for private registry                                      | None       (Conflicts with node.image.registryConfigJSON)               |
 | `node.image.registryConfigJSON`   | base64 encoded docker config json for the pull secret                  | None       (Conflicts with node.image.pullSecrets)                      |
 | `node.daemonset.resources`        | Configure Node sensor resource requests and limits (eBPF mode only)    | None       (Minimum setting of 250m CPU and 500Mi memory allowed). Default for GKE Autopilot is 750m CPU and 1.5Gi memory.<br><br><div class="warning">:warning: **Warning**:<br>If you configure resources, you must configure the CPU and Memory Resource requests and limits correctly for your node instances for the node sensor to run properly!</div> |
+| `node.daemonset.existingSecret`   | Existing secret ref name of the customer Kubernetes cluster            | None       (Optional)                                                   |
 | `falcon.cid`                      | CrowdStrike Customer ID (CID)                                          | None       (Required)                                                   |
 
 `falcon.cid` and `node.image.repository` are required values.

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -12,10 +12,14 @@ metadata:
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 data:
+  {{- if not .Values.node.daemonset.existingSecret }}
   FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
+  {{- end }}
   {{- range $key, $value := .Values.falcon }}
   {{- if and (or $value (eq ($value | toString) "false")) (ne $key "cid") }}
+  {{- if not (and ($.Values.node.daemonset.existingSecret) (eq $key "provisioning_token")) }}
   FALCONCTL_OPT_{{ $key | upper }}: {{ $value | quote }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if and .Values.node.enabled .Values.node.backend }}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -172,12 +172,11 @@ spec:
         {{- include "falcon-sensor.daemonsetResources" . | nindent 8 }}
         {{- end }}
         envFrom:
+        - configMapRef:
+            name: {{ include "falcon-sensor.fullname" . }}-config
         {{- if .Values.node.daemonset.existingSecret }}
         - secretRef:
             name: {{ .Values.node.daemonset.existingSecret }}
-        {{- else }}
-        - configMapRef:
-            name: {{ include "falcon-sensor.fullname" . }}-config
         {{- end }}
         volumeMounts:
           - name: falconstore

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -172,8 +172,13 @@ spec:
         {{- include "falcon-sensor.daemonsetResources" . | nindent 8 }}
         {{- end }}
         envFrom:
+        {{- if .Values.node.daemonset.existingSecret }}
+        - secretRef:
+            name: {{ .Values.node.daemonset.existingSecret }}
+        {{- else }}
         - configMapRef:
             name: {{ include "falcon-sensor.fullname" . }}-config
+        {{- end }}
         volumeMounts:
           - name: falconstore
             mountPath: /opt/CrowdStrike/falconstore

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -200,6 +200,9 @@
                                     "default": {}
                                 }
                             }
+                        },
+                        "existingSecret": {
+                            "type": "string"
                         }
                     }
                 },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -75,8 +75,10 @@ node:
     # Sets the max unavailable nodes. Default is 1 when no value exists.
     maxUnavailable: 1
 
-    # Use an existing secret as a replacement for the configMap
-    existingSecret:
+    # Use an existing secret as a complement for the configMap 
+    # `falcon.cid`` and `falcon.provisioning_token` are expected to be
+    # provisionned outside of this chart, to avoid storing sensitive data.
+    existingSecret: ""
 
   image:
     repository: falcon-node-sensor

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -75,6 +75,9 @@ node:
     # Sets the max unavailable nodes. Default is 1 when no value exists.
     maxUnavailable: 1
 
+    # Use an existing secret as a replacement for the configMap
+    existingSecret:
+
   image:
     repository: falcon-node-sensor
     pullPolicy: Always


### PR DESCRIPTION
Add support for an existing secret.  This is useful for one who wishes to use tools like external secret to provide the environment variables necessary (and prevent storing key/secret like clientID or provisioning token in git).

Skip injecting `falcon.cid` and `falcon.provisioning_token` in the configMap when `node.daemonset.existingSecret` is set.