### PR TITLE
Forcing the param namespaces to be a default empty string

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.26.1
+version: 1.26.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.26.1
+appVersion: 1.26.2
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -188,7 +188,7 @@ container:
       # list. For example:
       #
       # namespaces: ns1,ns2,ns3
-      namespaces:
+      namespaces: ""
 
       # Attempt to create the Falcon sensor pull secret in all Namespaces
       # instead of using "container.image.pullSecrets.namespaces"


### PR DESCRIPTION
if not forced to empty string, helm is taking the variable as an interface{}

without the default value : 
```
Error: template: falcon-sensor/templates/container_secret.yaml:15:30: executing "falcon-sensor/templates/container_secret.yaml" at <.Values.container.image.pullSecrets.namespaces>: wrong type for value; expected string; got interface {}
helm.go:84: [debug] template: falcon-sensor/templates/container_secret.yaml:15:30: executing "falcon-sensor/templates/container_secret.yaml" at <.Values.container.image.pullSecrets.namespaces>: wrong type for value; expected string; got interface {}
```