### PR TITLE
feat(falcon-sensor): allow helm hook manifests to be disabled

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.26.2
+version: 1.26.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.26.2
+appVersion: 1.26.3
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.node.enabled }}
+{{- if and .Values.node.enabled .Values.node.hooks.postDelete.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.node.enabled }}
+{{- if and .Values.node.enabled .Values.node.hooks.postDelete.enabled }}
 {{- if .Values.node.image.registryConfigJSON }}
 {{- $registry := .Values.node.image.registryConfigJSON }}
 apiVersion: v1

--- a/helm-charts/falcon-sensor/templates/serviceaccount_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/serviceaccount_cleanup.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.node.enabled .Values.node.hooks.postDelete.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,3 +12,4 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "0"
+{{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -255,6 +255,20 @@
                     "type": "integer",
                     "default": "30",
                     "pattern": "^[0-9]+$"
+                },
+                "hooks": {
+                    "type": "object",
+                    "properties": {
+                        "postDelete": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "default": "true"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -99,6 +99,11 @@ node:
   # How long to wait for Falcon pods to stop gracefully
   terminationGracePeriod: 30
 
+  hooks:
+    # Settings for the node post-delete helm hook
+    postDelete:
+      enabled: true
+
 container:
   # When enabled, Helm chart deploys the Falcon Container Sensor to Pods through Webhooks
   enabled: false


### PR DESCRIPTION
fixes: #278 

Allows for helm hooks to be optionally toggled off, the default behavior is that they are enabled for backward compatibility.

![image](https://github.com/CrowdStrike/falcon-helm/assets/47261237/21afd508-11ef-4047-ac35-1ec53f9f3a32)
