### PR TITLE
allow resource settings to be set for falcon sensor injector pod

### DIFF
--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -183,7 +183,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.container.resources | nindent 12 }}
     {{- if .Values.container.tolerations }}
       tolerations:
       {{- with .Values.container.tolerations }}

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -220,6 +220,7 @@ container:
 
   tolerations: []
 
+  # Configure the requests and limits of the injector container
   resources:
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
resource settings configured in `values.yaml` for falcon sensor injector pod
This is fix