### PR TITLE
wip: add cluster visibility to falcon-kac

### DIFF
--- a/helm-charts/falcon-kac/Chart.yaml
+++ b/helm-charts/falcon-kac/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.2.0-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.1.2
+appVersion: 1.2.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -168,6 +168,80 @@ spec:
           name: crowdstrike-falcon-vol0
         - mountPath: /var/private
           name: crowdstrike-falcon-vol1
+      - args:
+        - "client"
+        - "-app=watcher"
+        env:
+        - name: __CS_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: __CS_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: __CS_POD_NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        {{ if not .Values.clusterVisibility.resourceSnapshots.enabled -}}
+        - name: __CS_SNAPSHOTS_ENABLED
+          value: "false"
+        {{- end }}
+        {{ if .Values.clusterVisibility.resourceSnapshots.interval -}}
+        - name: __CS_SNAPSHOT_INTERVAL
+          value: {{ .Values.clusterVisibility.resourceSnapshots.interval }}
+        {{- end }}
+        {{- if not .Values.clusterVisibility.resourceWatcher.enabled -}}
+        - name: __CS_WATCH_EVENTS_ENABLED
+          value: "false"
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ include "falcon-kac.fullname" . }}-config
+        image: {{ include "falcon-kac.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: 4080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: falcon-watcher
+        ports:
+        - containerPort: 4080
+          name: healthcheck
+        resources:
+          {{- toYaml .Values.falconWatcherResources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /startz
+            port: 4080
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /tmp
+          name: crowdstrike-falcon-vol0
+        - mountPath: /var/private
+          name: crowdstrike-falcon-vol1
+        - mountPath: /var/falcon-watcher
+          name: crowdstrike-falcon-vol2
       - envFrom:
         - configMapRef:
             name: {{ include "falcon-kac.fullname" . }}-config
@@ -206,6 +280,8 @@ spec:
           name: crowdstrike-falcon-vol0
         - mountPath: /var/private/
           name: crowdstrike-falcon-vol1
+        - mountPath: /var/falcon-watcher
+          name: crowdstrike-falcon-vol2
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -232,6 +308,9 @@ spec:
       - name: crowdstrike-falcon-vol1
         emptyDir:
           sizeLimit: 4Ki
+      - name: crowdstrike-falcon-vol2
+        emptyDir:
+          sizeLimit: 64Mi
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -159,6 +159,33 @@
                 }
             }
         },
+        "clusterVisibility": {
+            "type": "object",
+            "properties": {
+                "resourceSnapshots": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": "true"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "default": "22h"
+                        }
+                    }
+                },
+                "resourceWatcher": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": "true"
+                        }
+                    }
+                }
+            }
+        },
         "annotations": {
             "type": "object",
             "default": {}
@@ -192,6 +219,33 @@
                                 ]
                             }
                         ]
+                    }
+                }
+            }
+        },
+        "falconWatcherResources": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -56,6 +56,31 @@ falcon:
   tags:
   provisioning_token:
 
+# These variables can be used to customize the way KAC provides visibility into
+# resources on your Kubernetes cluster. The variables are initially set to the
+# default values which will be used if they are commented out.
+clusterVisibility:
+  # KAC snapshots Kubernetes resources on a periodic basis and sends them to CrowdStrike
+  # cloud. This enables long living resources to be maintained in CrowdStrike cloud databases.
+  resourceSnapshots:
+    # If set to false, the snapshots are not taken and you may not see long lived
+    # Kubernetes resources in Falcon UI after about 7 days.
+    enabled: true
+    # The time interval between periodic snapshots. The default value of 22 hours is
+    # also the maximum value allowed. Minimum allowed value is 30 minutes. The format
+    # for this variable is HHhMMm. Some examples are 12h, 45m and 1h30m.
+    interval: 22h
+
+  # KAC watches Kubernetes cluster continuously for any action - creation, updates and deletion -
+  # on resources and sends events with the resource representation and the type of action
+  # to the CrowdStrike cloud.
+  resourceWatcher:
+    # If set to false, KAC does not watch the Kubernetes cluster and you will not be ables
+    # to see the latest state of the Kubernetes resources in the Falcon UI until a resource
+    # snapshot has been taken. Any resources deleted when KAC does not watch the Kubernetes
+    # cluster will not be shown as deleted in the Falcon UI.
+    enabled: true
+
 # Falcon KAC can usually discover the clusterName automatically so setting clusterName here is normally
 # not necessary, but in some cases the clusterName cannot be discovered by the KAC, e.g. for self-hosted
 # kubernetes clusters such as MicroK8s. In those case, the clusterName can be manually set here.
@@ -87,6 +112,14 @@ affinity:
           - amd64
 
 falconClientResources:
+  limits:
+    cpu: 750m
+    memory: 256Mi
+  requests:
+    cpu: 500m
+    memory: 256Mi
+
+falconWatcherResources:
   limits:
     cpu: 750m
     memory: 256Mi


### PR DESCRIPTION
This is creating a prerelease build of version `1.2.0-rc.1`. Ideally, this would be done from the working branch, but limitations in the [chart releaser tool](https://github.com/helm/chart-releaser) prevent this.