### PR TITLE
Add CriticalAddonsOnly toleration

### DIFF
--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -42,6 +42,9 @@ node:
         operator: "Equal"
         value: "spot"
         effect: "NoSchedule"
+      - effect: NoSchedule
+        key: CriticalAddonsOnly
+        operator: Exists
       # Daemonsets automatically get additional tolerations: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 
     # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity


### PR DESCRIPTION
This toleration let falcon run on EKS master nodes