### PR TITLE
Add support for running KAC on hostNetwork

### DIFF
--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -108,6 +108,7 @@ spec:
       containers:
       - args:
         - client
+        - "-port={{ .Values.webhookPort }}"
         env:
         - name: __CS_POD_NAMESPACE
           valueFrom:
@@ -171,6 +172,7 @@ spec:
       - args:
         - "client"
         - "-app=watcher"
+        - "-http-port={{ .Values.watcherPort }}"
         env:
         - name: __CS_POD_NAMESPACE
           valueFrom:
@@ -197,14 +199,14 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /livez
-            port: 4080
+            port: {{ .Values.watcherPort }}
             scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: falcon-watcher
         ports:
-        - containerPort: 4080
+        - containerPort: {{ .Values.watcherPort }}
           name: healthcheck
         resources:
           {{- toYaml .Values.falconWatcherResources | nindent 10 }}
@@ -219,7 +221,7 @@ spec:
           failureThreshold: 30
           httpGet:
             path: /startz
-            port: 4080
+            port: {{ .Values.watcherPort }}
             scheme: HTTP
           periodSeconds: 2
           successThreshold: 1
@@ -286,6 +288,12 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: {{ default "ClusterFirstWithHostNet" .Values.dnsPolicy }}
+      {{- else if .Values.dnsPolicy}}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
       volumes:
       - name: {{ include "falcon-kac.name" . }}-tls-certs

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -48,11 +48,17 @@
             "default": 1,
             "minimum": 1
         },
+        "watcherPort": {
+            "type": "integer",
+            "default": "4080",
+            "minimum": 1024,
+            "maximum": 65535
+        },
         "webhookPort": {
             "type": "integer",
             "default": "4433",
             "minimum": 1024,
-            "maximum": 32767
+            "maximum": 65535
         },
         "autoCertificateUpdate": {
             "type": "boolean",
@@ -318,6 +324,24 @@
             "type": [
                 "null",
                 "string"
+            ]
+        },
+        "hostNetwork": {
+            "type": "boolean",
+            "default": "false"
+        },
+        "dnsPolicy": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "default": null,
+            "enum": [
+                null,
+                "ClusterFirst",
+                "ClusterFirstWithHostNet",
+                "Default",
+                "None"
             ]
         },
         "webhook": {

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -29,6 +29,9 @@ replicas: 1
 # Configure the webhook Port
 webhookPort: 4443
 
+# Configure the watcher Port
+watcherPort: 4080
+
 # Auto update the certificates every time there is an update
 autoCertificateUpdate: true
 
@@ -146,6 +149,13 @@ webhook:
   failurePolicy: Ignore
   # Comma sparated list of namespaces in which we need to disable validation e.g test1,test2
   disableNamespaces:
+
+# Specifies if Falcon KAC should use hostNetwork mode. This is required in some scenarios such as when a
+# custom CNI is in use where control plane nodes cannot establish network communication with pods.
+hostNetwork: false
+
+# Define Falcon KAC POD DNS Policy, follows cluster default when not set and sets "ClusterFirstWithHostNet" when hostNetwork = true unless overriden
+dnsPolicy:
 
 # Number of pods for resourceQuota object
 resourceQuota:


### PR DESCRIPTION
This PR introduces support for running KAC on hostNetwork and setting of dnsPolicy which is needed when some scenarios such as when custom CNI's are in use and control plane nodes are not be able to initiate network connections to pods.

Additionally this change adds support for configuring the watcher port and fixes missing webhookPort from being passed to the container client.