### PR TITLE
relax CID validation pattern

### DIFF
--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -10,7 +10,7 @@
             "properties": {
                 "cid": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
+                    "pattern": "^.*$",
                     "example": [
                         "1234567890ABCDEF1234567890ABCDEF-12"
                     ]


### PR DESCRIPTION
The CID with used doesn't match the pattern from the helm chart, so we need to apply dirty hack to workaround this.