### PR TITLE
Remove default resources from admission controller

### DIFF
--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -143,7 +143,9 @@ spec:
         - containerPort: {{ .Values.webhookPort }}
           name: webhook-port
         resources:
+          {{- if .Values.falconClientResources }}
           {{- toYaml .Values.falconClientResources | nindent 10 }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -207,7 +209,9 @@ spec:
         - containerPort: 4080
           name: healthcheck
         resources:
+          {{- if .Values.falconWatcherResources }}
           {{- toYaml .Values.falconWatcherResources | nindent 10 }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -247,7 +251,9 @@ spec:
           timeoutSeconds: 1
         name: falcon-ac
         resources:
+          {{- if .Values.falconWatcherResources }}
           {{- toYaml .Values.falconAcResources | nindent 10 }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -111,29 +111,29 @@ affinity:
           values:
           - amd64
 
-falconClientResources:
-  limits:
-    cpu: 750m
-    memory: 384Mi
-  requests:
-    cpu: 500m
-    memory: 384Mi
+# falconClientResources:
+#   limits:
+#     cpu: 750m
+#     memory: 384Mi
+#   requests:
+#     cpu: 500m
+#     memory: 384Mi
 
-falconWatcherResources:
-  limits:
-    cpu: 750m
-    memory: 384Mi
-  requests:
-    cpu: 500m
-    memory: 384Mi
+# falconWatcherResources:
+#   limits:
+#     cpu: 750m
+#     memory: 384Mi
+#   requests:
+#     cpu: 500m
+#     memory: 384Mi
 
-falconAcResources:
-  limits:
-    cpu: 300m
-    memory: 256Mi
-  requests:
-    cpu: 300m
-    memory: 256Mi
+# falconAcResources:
+#   limits:
+#     cpu: 300m
+#     memory: 256Mi
+#   requests:
+#     cpu: 300m
+#     memory: 256Mi
 
 # Update Webhook and roll out new Deployment on helm upgrade
 autoDeploymentUpdate: true


### PR DESCRIPTION
Updated to match the sensor chart. It's hard to unset/remove cpu limits when they are set without workarounds.