### PR TITLE
cdp: set ClusterFirstWithHostNet for node sensor

### DIFF
--- a/helm-charts/falcon-sensor/templates/clusterrole.yaml
+++ b/helm-charts/falcon-sensor/templates/clusterrole.yaml
@@ -8,11 +8,11 @@ metadata:
     app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{ if .Values.container.enabled }}
+    {{- if .Values.container.enabled }}
     app.kubernetes.io/component: "container_sensor"
     {{ else if .Values.node.enabled }}
     app.kubernetes.io/component: "kernel_sensor"
-    {{ end }}
+    {{ end -}}
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 rules:
@@ -20,7 +20,7 @@ rules:
   - ""
   resources:
   - secrets
-  {{- if and .Values.node.enabled }}
+  {{- if .Values.node.enabled }}
   - pods
   - services
   - nodes

--- a/helm-charts/falcon-sensor/templates/clusterrolebinding.yaml
+++ b/helm-charts/falcon-sensor/templates/clusterrolebinding.yaml
@@ -8,11 +8,11 @@ metadata:
     app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{ if .Values.container.enabled }}
+    {{- if .Values.container.enabled }}
     app.kubernetes.io/component: "container_sensor"
     {{ else if .Values.node.enabled }}
     app.kubernetes.io/component: "kernel_sensor"
-    {{ end }}
+    {{ end -}}
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 subjects:

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.container.enabled }}
     app.kubernetes.io/component: "container_sensor"
+    {{ else if .Values.node.enabled }}
+    app.kubernetes.io/component: "kernel_sensor"
+    {{ end -}}
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 data:

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -180,6 +180,7 @@ spec:
       priorityClassName: {{ include "falcon-sensor.priorityClassName" . }}
     {{- end }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: true
       hostIPC: true
 {{- end }}


### PR DESCRIPTION
Currently, we are running in the hostnetwork.
Without ClusterFirstWithHostNet DNS configuration, we can't query the k8s cluster dns server (and its resources)