### PR TITLE
Updating common labels for consistency with other agents

### DIFF
--- a/helm-charts/falcon-image-analyzer/templates/_helpers.tpl
+++ b/helm-charts/falcon-image-analyzer/templates/_helpers.tpl
@@ -70,6 +70,8 @@ helm.sh/chart: {{ include "falcon-image-analyzer.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+crowdstrike.com/provider: crowdstrike
+crowdstrike.com/name: falcon-image-analyzer
 {{- end }}
 
 {{/*

--- a/helm-charts/falcon-self-hosted-registry-assessment/templates/_helpers.tpl
+++ b/helm-charts/falcon-self-hosted-registry-assessment/templates/_helpers.tpl
@@ -59,6 +59,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.executor.labels }}
 {{ .Values.executor.labels }}
 {{- end }}
+crowdstrike.com/provider: crowdstrike
+crowdstrike.com/name: ra-self-hosted-executor
 {{- end }}
 
 {{- define "ra-self-hosted-job-controller.labels" -}}
@@ -71,6 +73,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.jobController.labels }}
 {{ .Values.jobController.labels }}
 {{- end }}
+crowdstrike.com/provider: crowdstrike
+crowdstrike.com/name: ra-self-hosted-job-controller
 {{- end }}
 
 {{- define "ra-self-hosted.labels" -}}
@@ -83,6 +87,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.jobController.labels }}
 {{ .Values.jobController.labels }}
 {{- end }}
+crowdstrike.com/provider: crowdstrike
+crowdstrike.com/name: ra-self-hosted
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Labels like:
```
crowdstrike.com/provider: crowdstrike
crowdstrike.com/name: xxxx
```

are missing for SHRA and Image-Analyzer