### PR TITLE
cdp: add fsGroup as nobody group

### DIFF
--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -85,6 +85,11 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
     {{- end }}
+      # We add nobody fsGroup to allow default projected service account to be readable
+      # by extensibility processes (that run in a user namespace).
+      # It is set as supplemental group for any process in the container.
+      securityContext:
+        fsGroup: 65534
       initContainers:
       # This init container creates empty falconstore file so that when
       # it's mounted into the sensor-node-container, k8s would just use it


### PR DESCRIPTION
tldr:
sensor is running as UID 0.
cdp module is running in a user namespace => cdp can't access the  volumes  created by k8s

`"failed to get orchestration get in cluster config: open /var/run/secrets/kubernetes.io/serviceaccount/token: permission denied"`

issue also referred here https://github.com/kubernetes-sigs/external-dns/pull/1185