### PR TITLE
Add manual release github action

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,10 +7,11 @@ on:
       - main
     paths:
       - 'helm-charts/**'
+  workflow_dispatch:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This adds a manual way to deploy releases outside of PRs. This will be used for release candidates, testing release automation, etc. 