### PR TITLE
feat: Allow disable ValidatingWebhookConfiguration for kac

### DIFF
--- a/helm-charts/falcon-kac/README.md
+++ b/helm-charts/falcon-kac/README.md
@@ -157,6 +157,7 @@ When a new container image is available, you can update your Falcon KAC by passi
    ```
 
 ## Uninstall Falcon KAC
+
 - Uninstall the admission controller from the falcon-kac namespace:
   ```
   helm uninstall falcon-kac -n falcon-kac
@@ -166,6 +167,7 @@ When a new container image is available, you can update your Falcon KAC by passi
   ```
   kubectl delete ns falcon-kac
   ```
+
 # Falcon Configuration Options
 
 The following tables lists the Falcon KAC  configurable parameters and their default values.
@@ -184,3 +186,4 @@ The following tables lists the Falcon KAC  configurable parameters and their def
 | `clusterVisibility.resourceSnapshots.enabled`  | Enable cluster snapshots                              | `true`                |
 | `clusterVisibility.resourceSnapshots.interval` | Interval between cluster snapshots                    | `22h`                 |
 | `clusterVisibility.resourceWatcher.enabled`    | Enable Cluster Visbility                              | `true`                |
+| `webhoo.enable          `                      | Enable ValidatingWebhookConfiguration                 | `true`                |

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -309,6 +309,7 @@ spec:
         emptyDir:
           sizeLimit: 64Mi
 ---
+{{- if .Values.webhook.enable -}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -438,4 +439,4 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10
-
+{{- end }}

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -146,6 +146,10 @@ autoDeploymentUpdate: true
 nameOverride: ""
 fullnameOverride: ""
 webhook:
+  # If you don't need the validationWebhook cause you already have another application in place
+  # you can disable it completely
+  enable: true
+
   failurePolicy: Ignore
   # Comma sparated list of namespaces in which we need to disable validation e.g test1,test2
   disableNamespaces:


### PR DESCRIPTION
 If you don't need the validationWebhook cause you already have another application in place you can disable it completely