### PR TITLE
remove cluster-wide permissions

### DIFF
--- a/helm-charts/falcon-self-hosted-registry-assessment/templates/executor-role-binding.yaml
+++ b/helm-charts/falcon-self-hosted-registry-assessment/templates/executor-role-binding.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ include "ra-self-hosted-executor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ra-self-hosted.labels-executor" . | nindent 4 }}
 subjects:
@@ -10,5 +11,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "ra-self-hosted-executor.fullname" . }}

--- a/helm-charts/falcon-self-hosted-registry-assessment/templates/executor-role.yaml
+++ b/helm-charts/falcon-self-hosted-registry-assessment/templates/executor-role.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ include "ra-self-hosted-executor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "ra-self-hosted.labels-executor" . | nindent 4 }}
 rules:
@@ -9,7 +10,6 @@ rules:
     - ""
     resources:
     - secrets
-    - namespaces
     verbs:
     - get
     - watch


### PR DESCRIPTION
I've tested the deployment without cluster-wide permissions, and it looks good. I would like to avoid creating a ClusterRole for this deployment since the ServiceAccount `falcon-shra-executor` doesn't need permissions to get secrets from all namespaces.

fixes: #370 