### PR TITLE
Add missing post-delete-hook policy for node cleanup SA

### DIFF
--- a/helm-charts/falcon-sensor/templates/serviceaccount_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/serviceaccount_cleanup.yaml
@@ -12,4 +12,5 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- end }}


### PR DESCRIPTION
Add the "helm.sh/hook-delete-policy" annotation with values `before-hook-creation,hook-succeeded` to the falcon-sensor node cleanup service account.

This matches the annotation on the corresponding node cleanup DaemonSet and ensures that the resource will be removed after the post delete hook executes.