### PR TITLE
ASPM Relay - fix exec

### DIFF
--- a/helm-charts/aspm-relay/templates/role.yaml
+++ b/helm-charts/aspm-relay/templates/role.yaml
@@ -24,7 +24,7 @@ rules:
     resources: [ "jobs" ]
     verbs: [ "get", "list", "watch", "create" ]
   {{- end -}}
-  {{- if has "exec" .Values.ruleSet }}
+  {{- if has "exec" .Values.role.ruleSet }}
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["get", "create"]


### PR DESCRIPTION
This PR fixes a typo in role.yaml that causes exec method to not work properly.