### PR TITLE
ASPM Relay: Fix pod labels json

### DIFF
--- a/helm-charts/aspm-relay/templates/deployment.yaml
+++ b/helm-charts/aspm-relay/templates/deployment.yaml
@@ -43,9 +43,9 @@ spec:
             - name: ASPM_KUBERNETES_JOBS_IMAGE_ADDRESS
               value: {{ .Values.jobs.imageAddress }}
             - name: ASPM_KUBERNETES_JOBS_POD_LABELS
-              value: {{ .Values.jobs.podLabels }}
+              value: {{ .Values.jobs.podLabels | mustToJson | quote }}
             - name: ASPM_KUBERNETES_JOBS_PULL_SECRETS
-              value: "{{ toJson .Values.jobs.imagePullSecrets }}"
+              value: {{ .Values.jobs.imagePullSecrets | mustToJson | quote }}
           {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}


### PR DESCRIPTION
Pod labels were not passed correctly as an env, this PR fixes it.