### PR TITLE
Set the Falcon sensor cleanup node sleep time to infinity

### DIFF
--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -125,7 +125,7 @@ spec:
         imagePullPolicy: "{{ .Values.node.image.pullPolicy }}"
         args:
         - -c
-        - sleep 10
+        - sleep infinity
         command:
         - /bin/bash
         {{- if or .Values.node.gke.autopilot .Values.node.daemonset.resources }}


### PR DESCRIPTION
The node cleanup DaemonSet is executed as a post-delete hook, and it cleans up a Falcon sensor installation. It does this in the pod init-container, with the pod container just doing a noop sleep for 10 seconds.

In clusters with a large number of nodes, it's possible that the cleanup DaemonSet runs to completion and enters CrashLoopBackOff on a particular node, before it has been deployed to all nodes.

With ArgoCD, this can cause deleting an application to hang indefinitely, as its waiting for the cleanup DaemonSet to be successfully deployed on all nodes. Combined with the exponential backoff of Kubernetes, if it takes longer than 10 seconds to deploy the DaemonSet to all nodes, it virtually guarantees that at least one of the pods will not be in the "Running" state at any moment.

By modifying the sleep time to infinity, the pods remain in the "Running" state instead of "CrashLoopBackOff".