### PR TITLE
Ensure configurations work with WorkloadAllowlist

### DIFF
--- a/helm-charts/falcon-sensor/templates/_helpers.tpl
+++ b/helm-charts/falcon-sensor/templates/_helpers.tpl
@@ -134,11 +134,37 @@ args:
   - '-c'
   - >-
       echo "Running /opt/CrowdStrike/falcon-daemonset-init -i";
-{{- if .Values.node.gke.autopilot }}
-      /opt/CrowdStrike/falcon-daemonset-init -i
-{{- else -}}
       /opt/CrowdStrike/falcon-daemonset-init -i;
       echo "Running /opt/CrowdStrike/configure-cluster-id";
       test -f "/opt/CrowdStrike/configure-cluster-id" && /opt/CrowdStrike/configure-cluster-id || echo "/opt/CrowdStrike/configure-cluster-id not found. Skipping."
+{{- end -}}
+
+{{/*
+Create the name of the config map if GKE Autopilot is used.
+WorkloadAllowlists require an exact match for naming.
+*/}}
+{{- define "falcon-sensor.configMapName" -}}
+{{- if and .Values.node.gke.autopilot -}}
+{{- printf "falcon-node-sensor-config" -}}
+{{- else -}}
+{{- printf "%s-config" (include "falcon-sensor.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add label for WorkloadAllowlist for the deploy daemonset
+*/}}
+{{- define "falcon-sensor.workloadDeployAllowlistLabel" -}}
+{{- if and .Values.node.gke.autopilot .Values.node.enabled .Values.node.gke.deployAllowListVersion -}}
+{{- printf "cloud.google.com/matching-allowlist: \"crowdstrike-falconsensor-deploy-allowlist-%s\"" .Values.node.gke.deployAllowListVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add label for WorkloadAllowlist for the cleanup daemonset
+*/}}
+{{- define "falcon-sensor.workloadCleanupAllowlistLabel" -}}
+{{- if and .Values.node.gke.autopilot .Values.node.enabled .Values.node.gke.cleanupAllowListVersion -}}
+{{- printf "cloud.google.com/matching-allowlist: \"crowdstrike-falconsensor-cleanup-allowlist-%s\"" .Values.node.gke.cleanupAllowListVersion -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "falcon-sensor.fullname" . }}-config
+  name: {{ include "falcon-sensor.configMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ include "falcon-sensor.name" . }}"

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -146,7 +146,7 @@ spec:
         command: ["injector"]
         envFrom:
         - configMapRef:
-            name: {{ include "falcon-sensor.fullname" . }}-config
+            name: {{ include "falcon-sensor.configMapName" . }}
         ports:
         - name: https
           containerPort: {{ .Values.container.injectorPort }}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -56,6 +56,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        {{ include "falcon-sensor.workloadDeployAllowlistLabel" . }}
     spec:
     {{- if and (.Values.node.image.pullSecrets) (.Values.node.image.registryConfigJSON) }}
       {{- fail "node.image.pullSecrets and node.image.registryConfigJSON cannot be used together." }}
@@ -167,7 +168,7 @@ spec:
         {{- end }}
         envFrom:
         - configMapRef:
-            name: {{ include "falcon-sensor.fullname" . }}-config
+            name: {{ include "falcon-sensor.configMapName" . }}
         volumeMounts:
           - name: falconstore
             mountPath: /opt/CrowdStrike/falconstore

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -53,6 +53,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        {{ include "falcon-sensor.workloadCleanupAllowlistLabel" . }}
     spec:
     {{- if and (.Values.node.image.pullSecrets) (.Values.node.image.registryConfigJSON) }}
       {{- fail "node.image.pullSecrets and node.image.registryConfigJSON cannot be used together." }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -46,6 +46,16 @@
                         "autopilot": {
                             "type": "boolean",
                             "default": "false"
+                        },
+                        "deployAllowListVersion": {
+                            "type": "string",
+                            "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
+                            "default": ""
+                        },
+                        "cleanupAllowListVersion": {
+                            "type": "string",
+                            "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
+                            "default": ""
                         }
                     }
                 },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -10,8 +10,12 @@ node:
   backend: bpf
 
   # Enable for use on Google's GKE Autopilot clusters
+  # deployAllowListVersion - specify the version of the workload allowlist to use for the primary daemonset
+  # cleanupAllowListVersion - specify the version of the workload allowlist to use for the cleanup daemonset
   gke:
     autopilot: false
+    # deployAllowListVersion: ""
+    # cleanupAllowListVersion: ""
 
   daemonset:
     # Annotations to apply to the daemonset


### PR DESCRIPTION
- Add labels for troubleshooting the primary and cleanup daemonsets for AutoPilot.
- Set configMap name to be a static value when Autopilot is enabled