### PR TITLE
add checksums to the deployments of falcon-kac and falcon-sensor.

### DIFF
--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -82,6 +82,7 @@ spec:
         {{- end }}
       annotations:
         sensor.falcon-system.crowdstrike.com/injection: disabled
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
       {{- if or (.Values.autoDeploymentUpdate) (.Values.podAnnotations) }}
         {{- if .Values.autoDeploymentUpdate }}
         rollme: {{ randAlphaNum 5 | quote }}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -43,6 +43,7 @@ spec:
         {{- range $key, $value := .Values.node.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app: "{{ include "falcon-sensor.name" . }}"
         app.kubernetes.io/name: {{ include "falcon-sensor.name" . }}


### PR DESCRIPTION
Creates an annotation on deployment yaml for kac and sensor to force a restart of pods on configmap changes  (you change your CID, add new tags, etc).

Otherwise you need to run around restarting a bunch of a pods which gets old fast.

this impacted us using argocd:
https://github.com/argoproj/argo-cd/issues/13642

In which the developers are big meanie pants and tell me to go figure out my own problems instead providing a fix in their CICD system.