### PR TITLE
Add ability to run the cleanup Daemonset only

### DIFF
--- a/helm-charts/falcon-sensor/templates/_helpers.tpl
+++ b/helm-charts/falcon-sensor/templates/_helpers.tpl
@@ -168,3 +168,14 @@ Add label for WorkloadAllowlist for the cleanup daemonset
 {{- printf "cloud.google.com/matching-allowlist: \"crowdstrike-falconsensor-cleanup-allowlist-%s\"" .Values.node.gke.cleanupAllowListVersion -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create service account name for the cleanup daemonset
+*/}}
+{{- define "falcon-sensor.cleanupServiceAccountName" -}}
+{{- if not .Values.node.cleanupOnly -}}
+{{- printf "%s-node-cleanup" .Values.serviceAccount.name -}}
+{{- else -}}
+{{- printf "%s-node-cleanup-standalone" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.node.cleanupOnly }}
 {{- $falconSecretKeys := list "cid" "provisioning_token" }}
 
 apiVersion: v1
@@ -54,3 +55,4 @@ data:
   FALCON_RESOURCES: '{{ toJson .Values.container.sensorResources | b64enc }}'
   {{- end }}
   {{- end }}
+{{- end }}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.node.enabled }}
+{{- if and .Values.node.enabled (not .Values.node.cleanupOnly) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -17,9 +17,11 @@ metadata:
     {{- end }}
     {{- end }}
   annotations:
+    {{- if not .Values.node.cleanupOnly }}
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
   {{- if .Values.node.daemonset.annotations }}
     {{- range $key, $value := .Values.node.daemonset.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -144,7 +146,7 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: true
-      serviceAccountName: {{ .Values.serviceAccount.name }}-node-cleanup
+      serviceAccountName: {{ include "falcon-sensor.cleanupServiceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
       hostPID: true
 {{- end }}

--- a/helm-charts/falcon-sensor/templates/node_priorityclass.yaml
+++ b/helm-charts/falcon-sensor/templates/node_priorityclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.node.enabled }}
+{{- if and .Values.node.enabled (not .Values.node.cleanupOnly) }}
 {{- if or .Values.node.daemonset.priorityClassCreate .Values.node.gke.autopilot }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass

--- a/helm-charts/falcon-sensor/templates/node_secret.yaml
+++ b/helm-charts/falcon-sensor/templates/node_secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.node.enabled }}
+{{- if and .Values.node.enabled (not .Values.node.cleanupOnly) }}
 {{- if .Values.node.image.registryConfigJSON }}
 {{- $registry := .Values.node.image.registryConfigJSON }}
 apiVersion: v1

--- a/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
@@ -6,8 +6,11 @@ kind: Secret
 metadata:
   name: {{ include "falcon-sensor.fullname" . }}-pull-secret-cleanup
   namespace: {{ .Release.Namespace }}
+  {{- if not .Values.node.cleanupOnly }}
   annotations:
     "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+  {{- end }}
 data:
   .dockerconfigjson: {{ $registry }}
 type: kubernetes.io/dockerconfigjson

--- a/helm-charts/falcon-sensor/templates/serviceaccount.yaml
+++ b/helm-charts/falcon-sensor/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.node.cleanupOnly }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/helm-charts/falcon-sensor/templates/serviceaccount_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/serviceaccount_cleanup.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}-node-cleanup
+  name: {{ include "falcon-sensor.cleanupServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: "kernel_sensor"
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
   annotations:
+    {{- if not .Values.node.cleanupOnly }}
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "0"
+    {{- end }}
 {{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -5,13 +5,6 @@
         "falcon": {
             "type": "object",
             "properties": {
-                "cid": {
-                    "type": "string",
-                    "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
-                    "example": [
-                        "1234567890ABCDEF1234567890ABCDEF-12"
-                    ]
-                },
                 "trace": {
                     "type": [
                         "null",
@@ -521,41 +514,64 @@
     },
     "oneOf": [
         {
-            "properties": {
-                "falcon": {
-                    "properties": {
-                        "cid": {
-                            "type": "string",
-                            "minLength": 1
-                        }
-                    },
-                    "required": ["cid"]
-                }
-            },
-            "required": ["falcon"]
-        },
-        {
-            "properties": {
-                "falconSecret": {
-                    "properties": {
-                        "enabled": { "enum": [true] },
-                        "secretName": {
-                            "type": "string",
-                            "minLength": 1
-                        }
-                    },
-                    "required": ["enabled", "secretName"]
-                }
-            },
-            "required": ["falconSecret"],
-            "not": {
+            "if": {
                 "properties": {
-                    "falcon": {
-                        "required": ["cid"]
+                    "node": {
+                        "properties": {
+                            "cleanupOnly": {
+                                "type": ["null", "boolean"],
+                                "enum": [null, false]
+                            }
+                        }
                     }
-                },
-                "required": ["falcon"]
-            }
+                }
+            },
+            "then": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "falcon": {
+                                "properties": {
+                                    "cid": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
+                                        "example": [
+                                            "1234567890ABCDEF1234567890ABCDEF-12"
+                                        ]
+                                    }
+                                },
+                                "required": ["cid"]
+                            }
+                        },
+                        "required": ["falcon"]
+                    },
+                    {
+                        "properties": {
+                            "falconSecret": {
+                                "properties": {
+                                    "enabled": { "enum": [true] },
+                                    "secretName": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                },
+                                "required": ["enabled", "secretName"]
+                            }
+                        },
+                        "required": ["falconSecret"],
+                        "not": {
+                            "properties": {
+                                "falcon": {
+                                    "required": ["cid"]
+                                }
+                            },
+                            "required": ["falcon"]
+                        }
+                    }
+                ]
+            },
+            "else": {}
         }
     ]
 }

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -108,6 +108,9 @@ node:
     postDelete:
       enabled: true
 
+  # Enable, to run cleanup for the prior daemonset deployment
+  cleanupOnly: false
+
 container:
   # When enabled, Helm chart deploys the Falcon Container Sensor to Pods through Webhooks
   enabled: false


### PR DESCRIPTION
Setting `node.cleanupOnly` to `true` will run the cleanup daemonset when `node.enabled`.  The Daemonset will run indefinitely and only be removed during a helm uninstall to ensure cleanup runs on all nodes. 