### PR TITLE
fix: adjust the whitespace chomp to ensure the following annotation d…

### DIFF
--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: "container_sensor"
     {{ else if .Values.node.enabled }}
     app.kubernetes.io/component: "kernel_sensor"
-    {{ end -}}
+    {{- end }}
     crowdstrike.com/provider: crowdstrike
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 


### PR DESCRIPTION
Changing the whitespace chomp to ensure the annotations do not end up on the same line. This was causing issues with helm rendering the templates.

Error Message:
```
Use --debug flag to render out invalid YAML
Error: YAML parse error on falcon-sensor/templates/configmap.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```