### PR TITLE
Only set POD_NODE_NAME env if non autopilot

### DIFF
--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -128,12 +128,12 @@ spec:
               - DAC_READ_SEARCH
         {{- else }}
           readOnlyRootFilesystem: false
-        {{- end }}
         env:
           - name: POD_NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+        {{- end }}
       containers:
       - name: falcon-node-sensor
         image: "{{ include "falcon-sensor.image" . }}"


### PR DESCRIPTION
POD_NODE_NAME breaks autopilot installations because there is no matching deploy allowlist. 
Issue: https://github.com/CrowdStrike/falcon-helm/issues/422

This PR only sets the POD_NODE_NAME env if the installation is being done on a non autopilot cluster.