### PR TITLE
feat(falcon-sensor): add global values support for falcon-sensor

### DIFF
--- a/helm-charts/falcon-sensor/templates/_helpers.tpl
+++ b/helm-charts/falcon-sensor/templates/_helpers.tpl
@@ -191,3 +191,69 @@ Return namespace based on .Values.namespaceOverride or Release.Namespace
 {{- .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/* ### GLOBAL HELPERS ### */}}
+
+{{/*
+Get Falcon CID from global value if it exists
+*/}}
+{{- define "falcon-sensor.falconCid" -}}
+{{- if .Values.global.falcon.cid -}}
+{{- .Values.global.falcon.cid -}}
+{{- else -}}
+{{- .Values.falcon.cid -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if Falcon secret is enabled from global value if it exists
+*/}}
+{{- define "falcon-sensor.falconSecretEnabled" -}}
+{{- or .Values.global.falconSecret.enabled .Values.falconSecret.enabled -}}
+{{- end -}}
+
+{{/*
+Get Falcon secret name from global value if it exists
+*/}}
+{{- define "falcon-sensor.falconSecretName" -}}
+{{- if .Values.global.falconSecret.secretName -}}
+{{- .Values.global.falconSecret.secretName -}}
+{{- else -}}
+{{- .Values.falconSecret.secretName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get docker pull secret from global value if it exists
+*/}}
+{{- define "falcon-sensor.imagePullSecretName" -}}
+{{- if .Values.global.docker.pullSecret -}}
+{{- .Values.global.docker.pullSecret -}}
+{{- else -}}
+{{- if .Values.node.enabled -}}
+{{- .Values.node.image.pullSecrets | default "" -}}
+{{- else if .Values.container.image.pullSecrets.enable -}}
+{{- .Values.container.image.pullSecrets.name | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get docker registry config json from global value if it exists
+*/}}
+{{- define "falcon-sensor.registryConfigJson" -}}
+{{- if .Values.global.docker.registryConfigJSON -}}
+{{- .Values.global.docker.registryConfigJSON -}}
+{{- else -}}
+{{- if .Values.node.enabled -}}
+{{- .Values.node.image.registryConfigJSON | default "" -}}
+{{- else if .Values.container.image.pullSecrets.enable -}}
+{{- .Values.container.image.pullSecrets.registryConfigJSON | default "" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/falcon-sensor/templates/configmap.yaml
+++ b/helm-charts/falcon-sensor/templates/configmap.yaml
@@ -20,8 +20,8 @@ metadata:
     helm.sh/chart: {{ include "falcon-sensor.chart" . }}
 
 data:
-  {{- if not .Values.falconSecret.enabled }}
-  FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
+  {{- if not (include "falcon-sensor.falconSecretEnabled" . | eq "true") }}
+  FALCONCTL_OPT_CID: {{ include "falcon-sensor.falconCid" . }}
   {{- if .Values.falcon.provisioning_token }}
   FALCONCTL_OPT_PROVISIONING_TOKEN: {{ .Values.falcon.provisioning_token }}
   {{- end }}
@@ -43,7 +43,7 @@ data:
   FALCON_IMAGE: "{{ .Values.container.image.repository }}:{{ .Values.container.image.tag }}"
   FALCON_INJECTOR_LISTEN_PORT: "{{ .Values.container.injectorPort }}"
   {{- if .Values.container.image.pullSecrets.enable }}
-  FALCON_IMAGE_PULL_SECRET: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
+  FALCON_IMAGE_PULL_SECRET: {{ include "falcon-sensor.imagePullSecretName" . | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
   {{- end }}
   {{- if .Values.container.disablePodInjection }}
   INJECTION_DEFAULT_DISABLED: T

--- a/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
+++ b/helm-charts/falcon-sensor/templates/container_deployment_webhook.yaml
@@ -100,7 +100,7 @@ spec:
         runAsNonRoot: true
       {{- if .Values.container.image.pullSecrets.enable }}
       imagePullSecrets:
-        - name: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
+        - name: {{ include "falcon-sensor.imagePullSecretName" . | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
       {{- end }}
       {{- if .Values.container.azure.enabled }}
       initContainers:
@@ -142,9 +142,9 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-sensor.configMapName" . }}
-        {{- if .Values.falconSecret.enabled }}
+        {{- if (include "falcon-sensor.falconSecretEnabled" . | eq "true") }}
         - secretRef:
-            name: {{ .Values.falconSecret.secretName }}
+            name: {{ include "falcon-sensor.falconSecretName" . }}
         {{- end }}
         ports:
         - name: https

--- a/helm-charts/falcon-sensor/templates/container_secret.yaml
+++ b/helm-charts/falcon-sensor/templates/container_secret.yaml
@@ -1,17 +1,18 @@
 {{- if .Values.container.enabled }}
 {{- if .Values.container.image.pullSecrets.enable }}
-{{- if not .Values.container.image.pullSecrets.name }}
-{{- $registry := .Values.container.image.pullSecrets.registryConfigJSON }}
+{{- $imagePullSecretName := (include "falcon-sensor.imagePullSecretName" .) }}
+{{- if not ($imagePullSecretName) }}
+{{- $registryConfigJson := (include "falcon-sensor.registryConfigJson" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
+  name: {{ $imagePullSecretName | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .)) }}
   namespace: {{ include "falcon-sensor.namespace" . }}
 data:
-  .dockerconfigjson: {{ $registry }}
+  .dockerconfigjson: {{ $registryConfigJson }}
 type: kubernetes.io/dockerconfigjson
 {{- if or .Values.container.image.pullSecrets.namespaces .Values.container.image.pullSecrets.allNamespaces }}
-{{- $name := ( .Values.container.image.pullSecrets.name | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .))) }}
+{{- $name := ( $imagePullSecretName | default (printf "%s-pull-secret" (include "falcon-sensor.fullname" .))) }}
 {{- $myns := split "," .Values.container.image.pullSecrets.namespaces | default "" -}}
 {{- if .Values.container.image.pullSecrets.allNamespaces }}
 {{- $myns = list -}}
@@ -27,7 +28,7 @@ metadata:
   name: {{ $name }}
   namespace: {{ $value }}
 data:
-  .dockerconfigjson: {{ $registry }}
+  .dockerconfigjson: {{ $registryConfigJson }}
 type: kubernetes.io/dockerconfigjson
 {{- end }}
 {{- end }}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.node.enabled (not .Values.node.cleanupOnly) }}
+{{- $imagePullSecretName := include "falcon-sensor.imagePullSecretName" . }}
+{{- $registryConfigJson := include "falcon-sensor.registryConfigJson" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -59,15 +61,15 @@ spec:
         {{- end }}
         {{ include "falcon-sensor.workloadDeployAllowlistLabel" . }}
     spec:
-    {{- if and (.Values.node.image.pullSecrets) (.Values.node.image.registryConfigJSON) }}
+    {{- if and (len $imagePullSecretName) (len $registryConfigJson) }}
       {{- fail "node.image.pullSecrets and node.image.registryConfigJSON cannot be used together." }}
     {{- else }}
-    {{- if or (.Values.node.image.pullSecrets) (.Values.node.image.registryConfigJSON) }}
+    {{- if or (len $imagePullSecretName) (len $registryConfigJson) }}
       imagePullSecrets:
-      {{- if .Values.node.image.pullSecrets }}
-        - name: {{ .Values.node.image.pullSecrets }}
+      {{- if (len $imagePullSecretName) }}
+        - name: {{ $imagePullSecretName }}
       {{- end }}
-      {{- if .Values.node.image.registryConfigJSON }}
+      {{- if (len $registryConfigJson) }}
         - name: {{ include "falcon-sensor.fullname" . }}-pull-secret
       {{- end }}
     {{- end }}
@@ -175,9 +177,9 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-sensor.configMapName" . }}
-        {{- if .Values.falconSecret.enabled }}
+        {{- if (include "falcon-sensor.falconSecretEnabled" . | eq "true") }}
         - secretRef:
-            name: {{ .Values.falconSecret.secretName }}
+            name: {{ include "falcon-sensor.falconSecretName" . }}
         {{- end }}
         volumeMounts:
           - name: falconstore

--- a/helm-charts/falcon-sensor/templates/node_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_cleanup.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.node.enabled .Values.node.hooks.postDelete.enabled }}
+{{- $imagePullSecretName := include "falcon-sensor.imagePullSecretName" . }}
+{{- $registryConfigJson := include "falcon-sensor.registryConfigJson" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -57,15 +59,15 @@ spec:
         {{- end }}
         {{ include "falcon-sensor.workloadCleanupAllowlistLabel" . }}
     spec:
-    {{- if and (.Values.node.image.pullSecrets) (.Values.node.image.registryConfigJSON) }}
+    {{- if and (len $imagePullSecretName) (len $registryConfigJson) }}
       {{- fail "node.image.pullSecrets and node.image.registryConfigJSON cannot be used together." }}
     {{- else }}
-    {{- if or (.Values.node.image.pullSecrets) (.Values.node.image.registryConfigJSON) }}
+    {{- if or (len $imagePullSecretName) (len $registryConfigJson) }}
       imagePullSecrets:
-      {{- if .Values.node.image.pullSecrets }}
-        - name: {{ .Values.node.image.pullSecrets }}
+      {{- if (len $imagePullSecretName) }}
+        - name: {{ $imagePullSecretName }}
       {{- end }}
-      {{- if .Values.node.image.registryConfigJSON }}
+      {{- if (len $registryConfigJson) }}
         - name: {{ include "falcon-sensor.fullname" . }}-pull-secret-cleanup
       {{- end }}
     {{- end }}

--- a/helm-charts/falcon-sensor/templates/node_secret.yaml
+++ b/helm-charts/falcon-sensor/templates/node_secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.node.enabled (not .Values.node.cleanupOnly) }}
-{{- if .Values.node.image.registryConfigJSON }}
-{{- $registry := .Values.node.image.registryConfigJSON }}
+{{- if (include "falcon-sensor.registryConfigJson" .) }}
+{{- $registry := (include "falcon-sensor.registryConfigJson" .) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
+++ b/helm-charts/falcon-sensor/templates/node_secret_cleanup.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.node.enabled .Values.node.hooks.postDelete.enabled }}
-{{- if .Values.node.image.registryConfigJSON }}
-{{- $registry := .Values.node.image.registryConfigJSON }}
+{{- if (include "falcon-sensor.registryConfigJson" .) }}
+{{- $registryConfigJson := (include "falcon-sensor.registryConfigJson" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,7 +12,7 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
   {{- end }}
 data:
-  .dockerconfigjson: {{ $registry }}
+  .dockerconfigjson: {{ $registryConfigJson }}
 type: kubernetes.io/dockerconfigjson
 {{- end }}
 {{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -5,6 +5,16 @@
         "falcon": {
             "type": "object",
             "properties": {
+                "cid": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
+                    "example": [
+                        "1234567890ABCDEF1234567890ABCDEF-12"
+                    ]
+                },
                 "cloud": {
                     "type": [
                         "null",
@@ -504,18 +514,22 @@
         },
         "fullnameOverride": {
             "type": "string"
-        }
-    },
-    "falconSecret": {
-        "type": "object",
-        "properties": {
-            "enabled": {
-                "type": "boolean",
-                "default": "false"
-            },
-            "secretName": {
-                "type": "string",
-                "description": "The name of an existing secret in which Falcon specific secrets are stored."
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "falcon": {
+                    "type": "object",
+                    "properties": {
+                        "cid": {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$"
+                        }
+                    }
+                }
             }
         }
     },
@@ -537,43 +551,68 @@
                 "oneOf": [
                     {
                         "properties": {
-                            "falcon": {
+                            "global": {
+                                "type": "object",
                                 "properties": {
-                                    "cid": {
-                                        "type": "string",
-                                        "minLength": 1,
-                                        "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
-                                        "example": [
-                                            "1234567890ABCDEF1234567890ABCDEF-12"
-                                        ]
+                                    "falconSecret": {
+                                        "type": "object",
+                                        "required": ["enabled", "secretName"],
+                                        "properties": {
+                                            "enabled": { "enum": [true] },
+                                            "secretName": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            }
+                                        }
                                     }
-                                },
-                                "required": ["cid"]
+                                }
                             }
-                        },
-                        "required": ["falcon"]
+                        }
                     },
                     {
                         "properties": {
                             "falconSecret": {
+                                "type": "object",
+                                "required": ["enabled", "secretName"],
                                 "properties": {
                                     "enabled": { "enum": [true] },
                                     "secretName": {
+                                        "description": "The name of an existing secret in which Falcon specific secrets are stored.",
                                         "type": "string",
                                         "minLength": 1
                                     }
-                                },
-                                "required": ["enabled", "secretName"]
-                            }
-                        },
-                        "required": ["falconSecret"],
-                        "not": {
-                            "properties": {
-                                "falcon": {
-                                    "required": ["cid"]
                                 }
-                            },
-                            "required": ["falcon"]
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "global": {
+                                "type": "object",
+                                "properties": {
+                                    "falcon": {
+                                        "type": "object",
+                                        "required": ["cid"],
+                                        "properties": {
+                                            "cid": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "falcon": {
+                                "required": ["cid"],
+                                "properties": {
+                                    "cid": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 ]

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -290,3 +290,14 @@ falconSecret:
 # Only edit these if you know what you're doing
 nameOverride: ""
 fullnameOverride: ""
+
+# GLOBAL VALUES - for unified helm chart use only
+global:
+  falcon:
+    cid:
+  falconSecret:
+    enabled: false
+    secretName: ""
+  docker:
+    pullSecret: ""
+    registryConfigJSON: ""


### PR DESCRIPTION
These new helper functions to check for global values is to support changes that will be included in the unified falcon helm chart. These global values are values that can be shared across multiple helm charts when deployed from a parent helm chart.