### PR TITLE
feat(falcon-kac): add global values support for falcon-kac

### DIFF
--- a/helm-charts/falcon-kac/templates/_helpers.tpl
+++ b/helm-charts/falcon-kac/templates/_helpers.tpl
@@ -153,3 +153,61 @@ namespaceOverride should only be used when installing falcon-kac as a subchart o
 {{- .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/* ### GLOBAL HELPERS ### */}}
+
+{{/*
+Get Falcon CID from global value if it exists
+*/}}
+{{- define "falcon-kac.falconCid" -}}
+{{- if .Values.global.falcon.cid -}}
+{{- .Values.global.falcon.cid -}}
+{{- else -}}
+{{- .Values.falcon.cid -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if Falcon secret is enabled from global value if it exists
+*/}}
+{{- define "falcon-kac.falconSecretEnabled" -}}
+{{- if .Values.global.falconSecret.enabled -}}
+{{- .Values.global.falconSecret.enabled -}}
+{{- else -}}
+{{- .Values.falconSecret.enabled -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get Falcon secret name from global value if it exists
+*/}}
+{{- define "falcon-kac.falconSecretName" -}}
+{{- if .Values.global.falconSecret.secretName -}}
+{{- .Values.global.falconSecret.secretName -}}
+{{- else -}}
+{{- .Values.falconSecret.secretName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get docker pull secret from global value if it exists
+*/}}
+{{- define "falcon-kac.imagePullSecret" -}}
+{{- if .Values.global.docker.pullSecret -}}
+{{- .Values.global.docker.pullSecret -}}
+{{- else -}}
+{{- .Values.image.pullSecrets | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get docker registry config json from global value if it exists
+*/}}
+{{- define "falcon-kac.registryConfigJson" -}}
+{{- if .Values.global.docker.registryConfigJSON -}}
+{{- .Values.global.docker.registryConfigJSON -}}
+{{- else -}}
+{{- .Values.image.registryConfigJSON | default "" -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/falcon-kac/templates/configmap.yaml
+++ b/helm-charts/falcon-kac/templates/configmap.yaml
@@ -10,8 +10,8 @@ metadata:
 data:
   __CS_ADMISSION_CONTROL_ENABLED: {{ .Values.admissionControl.enabled | quote }}
   {{- include "falcon-kac.generateWatcherEnvVars" . | nindent 2 }}
-  {{- if not .Values.falconSecret.enabled }}
-  FALCONCTL_OPT_CID: {{ .Values.falcon.cid }}
+  {{- if not (include "falcon-kac.falconSecretEnabled" . | eq "true") }}
+  FALCONCTL_OPT_CID: {{ include "falcon-kac.falconCid" . }}
   {{- if .Values.falcon.provisioning_token }}
   FALCONCTL_OPT_PROVISIONING_TOKEN: {{ .Values.falcon.provisioning_token }}
   {{- end }}

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -30,6 +30,10 @@
 {{- $tlsCert := $cert.Cert | b64enc }}
 {{- $tlsKey := $cert.Key | b64enc }}
 {{- $caCert := $ca.Cert | b64enc -}}
+{{- $falconSecretEnabled := include "falcon-kac.falconSecretEnabled" . | eq "true" }}
+{{- $falconSecretName := include "falcon-kac.falconSecretName" . }}
+{{- $imagePullSecret := include "falcon-kac.imagePullSecret" . }}
+{{- $registryConfigJson := include "falcon-kac.registryConfigJson" . }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -94,15 +98,15 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-    {{- if and (.Values.image.pullSecrets) (.Values.image.registryConfigJSON) }}
+    {{- if and $imagePullSecret $registryConfigJson }}
       {{- fail "image.pullSecrets and image.registryConfigJSON cannot be used together." }}
     {{- else -}}
-    {{- if or (.Values.image.pullSecrets) (.Values.image.registryConfigJSON) }}
+    {{- if or $imagePullSecret $registryConfigJson }}
       imagePullSecrets:
-      {{- if .Values.image.pullSecrets }}
-        - name: {{ .Values.image.pullSecrets }}
+      {{- if $imagePullSecret }}
+        - name: {{ $imagePullSecret }}
       {{- end }}
-      {{- if .Values.image.registryConfigJSON }}
+      {{- if $registryConfigJson }}
         - name: {{ include "falcon-kac.fullname" . }}-pull-secret
       {{- end }}
     {{- end }}
@@ -131,9 +135,9 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-kac.fullname" . }}-config
-        {{- if .Values.falconSecret.enabled }}
+        {{- if $falconSecretEnabled }}
         - secretRef:
-            name: {{ .Values.falconSecret.secretName }}
+            name: {{ $falconSecretName }}
         {{- end }}
         image: {{ include "falcon-kac.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -203,9 +207,9 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-kac.fullname" . }}-config
-        {{- if .Values.falconSecret.enabled }}
+        {{- if $falconSecretEnabled }}
         - secretRef:
-            name: {{ .Values.falconSecret.secretName }}
+            name: {{ $falconSecretName }}
         {{- end }}
         image: {{ include "falcon-kac.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -250,9 +254,9 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ include "falcon-kac.fullname" . }}-config
-        {{- if .Values.falconSecret.enabled }}
+        {{- if $falconSecretEnabled }}
         - secretRef:
-            name: {{ .Values.falconSecret.secretName }}
+            name: {{ $falconSecretName }}
         {{- end }}
         image: {{ include "falcon-kac.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/helm-charts/falcon-kac/templates/kac_pullsecret.yaml
+++ b/helm-charts/falcon-kac/templates/kac_pullsecret.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.image.registryConfigJSON  }}
-{{- $registry := .Values.image.registryConfigJSON }}
+{{- $registryConfigJson := include "falcon-kac.registryConfigJson" . }}
+{{- if $registryConfigJson  }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,6 +8,6 @@ metadata:
   labels:
     {{- include "falcon-kac.labels" . | nindent 4 }}
 data:
-  .dockerconfigjson: {{ $registry }}
+  .dockerconfigjson: {{ $registryConfigJson }}
 type: kubernetes.io/dockerconfigjson
 {{- end }}

--- a/helm-charts/falcon-kac/templates/role.yaml
+++ b/helm-charts/falcon-kac/templates/role.yaml
@@ -32,7 +32,7 @@ rules:
   verbs:
   - '*'
 
-{{- if .Values.falconSecret.enabled }}
+{{- if (include "falcon-kac.falconSecretEnabled" . | eq "true") }}
 - apiGroups:
     - ""
   resources:

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -97,7 +97,10 @@
             "type": "object",
             "properties": {
                 "cid": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
                     "example": [
                         "1234567890ABCDEF1234567890ABCDEF-12"
@@ -404,57 +407,91 @@
                     ]
                 }
             }
-        }
-    },
-    "falconSecret": {
-        "type": "object",
-        "properties": {
-            "enabled": {
-                "type": "boolean",
-                "default": "false"
-            },
-            "secretName": {
-                "type": "string",
-                "description": "The name of an existing secret in which Falcon specific secrets are stored."
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "falcon": {
+                    "type": "object",
+                    "properties": {
+                        "cid": {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$"
+                        }
+                    }
+                }
             }
         }
     },
     "oneOf": [
         {
             "properties": {
-                "falcon": {
+                "falconSecret": {
+                    "required": ["enabled", "secretName"],
                     "properties": {
-                        "cid": {
+                        "enabled": {
+                            "enum": [true]
+                        },
+                        "secretName": {
+                            "description": "The name of an existing secret in which Falcon specific secrets are stored.",
                             "type": "string",
                             "minLength": 1
                         }
-                    },
-                    "required": ["cid"]
+                    }
                 }
-            },
-            "required": ["falcon"]
+            }
         },
         {
             "properties": {
-                "falconSecret": {
+                "global": {
+                    "type": "object",
                     "properties": {
-                        "enabled": { "enum": [true] },
-                        "secretName": {
-                            "type": "string",
-                            "minLength": 1
+                        "falconSecret": {
+                            "type": "object",
+                            "required": ["enabled", "secretName"],
+                            "properties": {
+                                "enabled": { "enum": [true] },
+                                "secretName": {
+                                    "type": "string",
+                                    "minLength": 1
+                                }
+                            }
                         }
-                    },
-                    "required": ["enabled", "secretName"]
-                }
-            },
-            "required": ["falconSecret"],
-            "not": {
-                "properties": {
-                    "falcon": {
-                        "required": ["cid"]
                     }
-                },
-                "required": ["falcon"]
+                }
+            }
+        },
+        {
+            "properties": {
+                "falcon": {
+                    "required": ["cid"],
+                    "properties": {
+                        "cid": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "properties": {
+                "global": {
+                    "type": "object",
+                    "properties": {
+                        "falcon": {
+                            "type": "object",
+                            "required": ["cid"],
+                            "properties": {
+                                "cid": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     ]

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -178,3 +178,14 @@ dnsPolicy:
 # Number of pods for resourceQuota object
 resourceQuota:
   pods: 2
+
+# GLOBAL VALUES - for unified helm chart use only
+global:
+  falcon:
+    cid:
+  falconSecret:
+    enabled: false
+    secretName: ""
+  docker:
+    pullSecret: ""
+    registryConfigJSON: ""


### PR DESCRIPTION
These new helper functions to check for global values is to support changes that will be included in the unified falcon helm chart. These global values are values that can be shared across multiple helm charts when deployed from a parent helm chart.