### PR TITLE
feat(falcon-iar): add global values support for falcon-image-analyzer

### DIFF
--- a/helm-charts/falcon-image-analyzer/templates/_helpers.tpl
+++ b/helm-charts/falcon-image-analyzer/templates/_helpers.tpl
@@ -172,7 +172,7 @@ runAsGroup: {{ .Values.securityContext.runAsGroup | default 0 }}
 {{- end }}
 {{- end }}
 
-{{- define "falcon-image-analyzer.imagePullSecret" }}
+{{- define "falcon-image-analyzer.pullSecretFromAPIToken" }}
 {{- with .Values.crowdstrikeConfig }}
 {{- if or (eq .agentRegion "us-gov-1") (eq .agentRegion "usgov1") (eq .agentRegion "us-gov1") (eq .agentRegion "gov1") (eq .agentRegion "gov-1") }}
 {{- printf "{\"auths\":{\"registry.laggar.gcw.crowdstrike.com\":{\"username\":\"fc-%s\",\"password\":\"%s\",\"email\":\"image-assessment@crowdstrike.com\",\"auth\":\"%s\"}}}" (first (regexSplit "-" (lower .cid) -1)) .dockerAPIToken (printf "fc-%s:%s" (first (regexSplit "-" (lower .cid) -1)) .dockerAPIToken | b64enc) | b64enc }}
@@ -205,5 +205,52 @@ namespaceOverride should only be used when installing falcon-image-analyzer as a
 {{- .Values.namespaceOverride -}}
 {{- else -}}
 {{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/* ### GLOBAL HELPERS ### */}}
+
+{{/*
+Get Falcon CID from global value if it exists
+*/}}
+{{- define "falcon-image-analyzer.falconCid" -}}
+{{- if .Values.global.falcon.cid -}}
+{{- .Values.global.falcon.cid -}}
+{{- else -}}
+{{- .Values.crowdstrikeConfig.cid -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get Falcon secret name from global value if it exists
+*/}}
+{{- define "falcon-image-analyzer.falconSecretName" -}}
+{{- if .Values.global.falconSecret.secretName -}}
+{{- .Values.global.falconSecret.secretName -}}
+{{- else -}}
+{{- .Values.crowdstrikeConfig.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get docker pull secret from global value if it exists
+*/}}
+{{- define "falcon-image-analyzer.imagePullSecret" -}}
+{{- if .Values.global.docker.pullSecret -}}
+{{- .Values.global.docker.pullSecret -}}
+{{- else -}}
+{{- .Values.image.pullSecret | default "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get docker registry config json from global value if it exists
+*/}}
+{{- define "falcon-image-analyzer.registryConfigJson" -}}
+{{- if .Values.global.docker.registryConfigJSON -}}
+{{- .Values.global.docker.registryConfigJSON -}}
+{{- else -}}
+{{- .Values.image.registryConfigJSON | default "" -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/falcon-image-analyzer/templates/configmap.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   SEND_SCAN_STATS: {{ .Values.scanStats.enabled | quote }}
   AGENT_HELM_VERSION: {{ .Chart.Version | quote }}
   LOG_OUTPUT: {{ .Values.log.output | quote }}
-  AGENT_CID: {{ .Values.crowdstrikeConfig.cid | quote }}
+  AGENT_CID: {{ include "falcon-image-analyzer.falconCid" . | quote }}
   AGENT_CLUSTER_NAME: {{ .Values.crowdstrikeConfig.clusterName | quote }}
   AGENT_REGISTRY_CREDENTIALS: {{ .Values.privateRegistries.credentials | quote }}
   AGENT_NAMESPACE_EXCLUSIONS: {{ .Values.exclusions.namespace | quote }}

--- a/helm-charts/falcon-image-analyzer/templates/daemonset.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/daemonset.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.daemonset.enabled }}
+{{- $imagePullSecret := include "falcon-image-analyzer.imagePullSecret" . }}
+{{- $registryConfigJson := include "falcon-image-analyzer.registryConfigJson" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -22,17 +24,17 @@ spec:
       labels:
     {{- include "falcon-image-analyzer.labels" . | nindent 8 }}
     spec:
-      {{- if or (.Values.image.pullSecret) (.Values.image.registryConfigJSON) (.Values.crowdstrikeConfig.dockerAPIToken) }}
+      {{- if or $imagePullSecret $registryConfigJson (.Values.crowdstrikeConfig.dockerAPIToken) }}
       imagePullSecrets:
-        {{- if and (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
+        {{- if and (.Values.crowdstrikeConfig.dockerAPIToken) $registryConfigJson }}
           {{- fail "crowdstrikeConfig.dockerAPIToken and image.registryConfigJSON cannot be used together." }}
         {{- else -}}
-        {{ if or (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
+        {{ if or (.Values.crowdstrikeConfig.dockerAPIToken) $registryConfigJson }}
         - name: {{ include "falcon-image-analyzer.fullname" . }}-pull-secret
         {{- end }}
         {{- end }}
-        {{- if .Values.image.pullSecret }}
-        - name: {{ .Values.image.pullSecret }}
+        {{- if $imagePullSecret }}
+        - name: {{ $imagePullSecret }}
         {{- end }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name | default ( include "falcon-image-analyzer.fullname" . ) }}
@@ -91,8 +93,8 @@ spec:
             - configMapRef:
                 name: {{ include "falcon-image-analyzer.fullname" . }}
             - secretRef:
-                {{- if .Values.crowdstrikeConfig.existingSecret }}
-                name: {{ .Values.crowdstrikeConfig.existingSecret }}
+                {{- if (include "falcon-image-analyzer.falconSecretName" .) }}
+                name: {{ include "falcon-image-analyzer.falconSecretName" . }}
                 {{- else }}
                 name: {{ include "falcon-image-analyzer.fullname" . }}
                 {{- end }}

--- a/helm-charts/falcon-image-analyzer/templates/deployment.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/deployment.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.deployment.enabled }}
+{{- $imagePullSecret := include "falcon-image-analyzer.imagePullSecret" . }}
+{{- $registryConfigJson := include "falcon-image-analyzer.registryConfigJson" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,17 +25,17 @@ spec:
       labels:
     {{- include "falcon-image-analyzer.labels" . | nindent 8 }}
     spec:
-      {{- if or (.Values.image.pullSecret) (.Values.image.registryConfigJSON) (.Values.crowdstrikeConfig.dockerAPIToken) }}
+      {{- if or $imagePullSecret $registryConfigJson (.Values.crowdstrikeConfig.dockerAPIToken) }}
       imagePullSecrets:
-        {{- if and (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
+        {{- if and (.Values.crowdstrikeConfig.dockerAPIToken) $registryConfigJson }}
           {{- fail "crowdstrikeConfig.dockerAPIToken and image.registryConfigJSON cannot be used together." }}
         {{- else -}}
-        {{ if or (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
+        {{ if or (.Values.crowdstrikeConfig.dockerAPIToken) $registryConfigJson }}
         - name: {{ include "falcon-image-analyzer.fullname" . }}-pull-secret
         {{- end }}
         {{- end }}
-        {{- if .Values.image.pullSecret }}
-        - name: {{ .Values.image.pullSecret }}
+        {{- if $imagePullSecret }}
+        - name: {{ $imagePullSecret }}
         {{- end }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name | default ( include "falcon-image-analyzer.fullname" . ) }}
@@ -102,8 +104,8 @@ spec:
             - configMapRef:
                 name: {{ include "falcon-image-analyzer.fullname" . }}
             - secretRef:
-                {{- if .Values.crowdstrikeConfig.existingSecret }}
-                name: {{ .Values.crowdstrikeConfig.existingSecret }}
+                {{- if (include "falcon-image-analyzer.falconSecretName" .) }}
+                name: {{ include "falcon-image-analyzer.falconSecretName" . }}
                 {{- else }}
                 name: {{ include "falcon-image-analyzer.fullname" . }}
                 {{- end }}

--- a/helm-charts/falcon-image-analyzer/templates/docker-secret.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/docker-secret.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Values.crowdstrikeConfig.dockerAPIToken) (.Values.image.registryConfigJSON) }}
+{{ if or (.Values.crowdstrikeConfig.dockerAPIToken) (include "falcon-image-analyzer.registryConfigJson" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,9 +9,9 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
 {{- if .Values.crowdstrikeConfig.dockerAPIToken }}
-  .dockerconfigjson: {{ template "falcon-image-analyzer.imagePullSecret" . }}
+  .dockerconfigjson: {{ template "falcon-image-analyzer.pullSecretFromAPIToken" . }}
 {{- end }}
-{{- if .Values.image.registryConfigJSON }}
-  .dockerconfigjson: {{ .Values.image.registryConfigJSON }}
+{{- if (include "falcon-image-analyzer.registryConfigJson" .) }}
+  .dockerconfigjson: {{ include "falcon-image-analyzer.registryConfigJson" . }}
 {{- end }}
 {{- end }}

--- a/helm-charts/falcon-image-analyzer/templates/secret.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.crowdstrikeConfig.existingSecret -}}
+{{- if not (include "falcon-image-analyzer.falconSecretName" .) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm-charts/falcon-image-analyzer/values.schema.json
+++ b/helm-charts/falcon-image-analyzer/values.schema.json
@@ -133,8 +133,7 @@
         "crowdstrikeConfig": {
             "type": "object",
             "required": [
-                "clusterName",
-                "cid"
+                "clusterName"
             ],
             "properties": {
                 "agentMaxConsumerThreads": {
@@ -181,7 +180,10 @@
                     ]
                 },
                 "cid": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "description": "CrowdStrike CID",
                     "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$",
                     "example": [
@@ -201,28 +203,7 @@
                 "clientID": [
                     "clientSecret"
                 ]
-            },
-            "allOf": [
-                {
-                    "if": {
-                        "properties": {
-                            "existingSecret": {
-                                "const": ""
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "clientID": {
-                                "pattern": "^[a-zA-Z0-9]{32}$"
-                            },
-                            "clientSecret": {
-                                "pattern": "^[a-zA-Z0-9]{40}$"
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         },
         "proxyConfig": {
             "default": {},
@@ -247,6 +228,23 @@
                     ]
                 }
             }
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "falcon": {
+                    "type": "object",
+                    "properties": {
+                        "cid": {
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "pattern": "^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$"
+                        }
+                    }
+                }
+            }
         }
     },
     "oneOf": [
@@ -262,13 +260,13 @@
             },
             "additionalProperties": {
                 "daemonset": {
-                  "properties": {
-                     "enabled": {
-                     "const": false
+                    "properties": {
+                         "enabled": {
+                            "const": false
+                        }
+                    }
                 }
-              }
-          }
-        }
+            }
         },
         {
             "properties": {
@@ -312,6 +310,80 @@
                                 "pattern": "^(docker|containerd|crio|podman)$"
                             }
                         }
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "global": {
+                        "properties": {
+                            "falcon": {
+                                "properties": {
+                                    "cid": {
+                                        "const": null
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "crowdstrikeConfig": {
+                        "type": "object",
+                        "required": ["cid"],
+                        "properties": {
+                            "cid": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "if": {
+                "properties": {
+                    "global": {
+                        "properties": {
+                            "falconSecret": {
+                                "properties": {
+                                    "secretName": {
+                                        "const": ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "crowdstrikeConfig": {
+                        "allOf": [
+                            {
+                                "if": {
+                                    "properties": {
+                                        "existingSecret": {
+                                            "const": ""
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "properties": {
+                                        "clientID": {
+                                            "pattern": "^[a-zA-Z0-9]{32}$"
+                                        },
+                                        "clientSecret": {
+                                            "pattern": "^[a-zA-Z0-9]{40}$"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             }

--- a/helm-charts/falcon-image-analyzer/values.yaml
+++ b/helm-charts/falcon-image-analyzer/values.yaml
@@ -169,7 +169,7 @@ crowdstrikeConfig:
   enableDebug: "false"
   clientID: ""
   clientSecret: ""
-  cid: ""
+  cid:
 
   # Use the value for the crowdstrike Artifactory
   # Token retrieved by calling container-security
@@ -189,3 +189,13 @@ proxyConfig:
   HTTP_PROXY: ""
   HTTPS_PROXY: ""
   NO_PROXY: ""
+
+# GLOBAL VALUES - for unified helm chart use only
+global:
+  falcon:
+    cid:
+  falconSecret:
+    secretName: ""
+  docker:
+    pullSecret: ""
+    registryConfigJSON: ""


### PR DESCRIPTION
These new helper functions to check for global values is to support changes that will be included in the unified falcon helm chart. These global values are values that can be shared across multiple helm charts when deployed from a parent helm chart.