### PR TITLE
Support KAC communication with Falcon Image Analyzer

### DIFF
--- a/helm-charts/falcon-kac/README.md
+++ b/helm-charts/falcon-kac/README.md
@@ -218,3 +218,4 @@ The following tables lists the Falcon KAC configurable parameters and their defa
 | `admissionControl.enabled`                     | Enable Admission Control                                                                                                           | `true`                                                        |
 | `falconSecret.enabled`                         | Enable k8s secrets to inject sensitive Falcon values                                                                               | false      (Must be true if falcon.cid is not set)            |
 | `falconSecret.secretName`                      | Existing k8s secret name to inject sensitive Falcon values.<br> The secret must be under the same namespace as the KAC deployment. | None       (Existing secret must include `FALCONCTL_OPT_CID`) |
+| `falconImageAnalyzerNamespace`                 | Falcon Image Analyzer namespace | falcon-image-analyzer |

--- a/helm-charts/falcon-kac/templates/clusterrole.yaml
+++ b/helm-charts/falcon-kac/templates/clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
   - nodes
   - pods
   - replicationcontrollers
+  - secrets
   - services
   verbs:
   - get

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -132,6 +132,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        {{- if .Values.falconImageAnalyzerNamespace }}
+        - name: __CS_IAR_NAMESPACE
+          value: {{ .Values.falconImageAnalyzerNamespace | quote }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ include "falcon-kac.fullname" . }}-config

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -407,6 +407,10 @@
                     ]
                 }
             }
+        },
+        "falconImageAnalyzerNamespace": {
+            "type": "string",
+            "default": "falcon-image-analyzer"
         }
     }
 }

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -104,6 +104,11 @@ clusterVisibility:
 # Important Note: if the clusterName is detected by the agent, this value will be overwritten
 clusterName: ""
 
+# Falcon Image Analyzer namespace
+# This variable can be used to override the Falcon Image Analyzer namespace
+# from its default value of "falcon-image-analyzer"
+falconImageAnalyzerNamespace: ""
+
 # Annotations to apply to the webhook deployment
 annotations: {}
 


### PR DESCRIPTION
KAC version 7.31 can communicate with Falcon Image Analyzer (IAR) to request Image Analalysis
KAC needs to know the namespace of Falcon Image Analyzer (IAR) in order to discover if IAR is installed.
It assumes namespace of "falcon-image-analyzer" but there needs to be a way to override that namespace if Falcon Image Analyzer (IAR) is installed into a different namespace
KAC also needs permission to read CA cert from IAR tls secret