### PR TITLE
Add permissions for resources covered by KAC extended visibility

### DIFF
--- a/helm-charts/falcon-kac/templates/_helpers.tpl
+++ b/helm-charts/falcon-kac/templates/_helpers.tpl
@@ -100,6 +100,7 @@ Create Watcher container environment variables
 {{- $snapshotsEnabled := true -}}
 {{- $snapshotInterval := "22h" -}}
 {{- $watcherEnabled := true -}}
+{{- $configMapEnabled := true -}}
 {{- if .Values.clusterVisibility -}}
 {{- if .Values.clusterVisibility.resourceSnapshots -}}
   {{- if ne .Values.clusterVisibility.resourceSnapshots.enabled nil -}}
@@ -114,10 +115,16 @@ Create Watcher container environment variables
   {{ $watcherEnabled = .Values.clusterVisibility.resourceWatcher.enabled -}}
   {{- end -}}
 {{- end -}}
+{{- if .Values.clusterVisibility.resourceConfigMap -}}
+  {{- if ne .Values.clusterVisibility.resourceConfigMap.enabled nil -}}
+  {{ $configMapEnabled = .Values.clusterVisibility.resourceConfigMap.enabled -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}
 __CS_SNAPSHOTS_ENABLED: {{ $snapshotsEnabled | toString | quote }}
 __CS_SNAPSHOT_INTERVAL: {{ $snapshotInterval | toString | quote }}
 __CS_WATCH_EVENTS_ENABLED: {{ $watcherEnabled | toString | quote }}
+__CS_VISIBILITY_CONFIGMAPS_ENABLED: {{ $configMapEnabled | toString | quote }}
 {{- end -}}
 
 {{- define "validateValues" }}

--- a/helm-charts/falcon-kac/templates/clusterrole.yaml
+++ b/helm-charts/falcon-kac/templates/clusterrole.yaml
@@ -13,6 +13,9 @@ rules:
   - pods
   - replicationcontrollers
   - services
+  - secrets
+  - configmaps
+  - serviceaccounts
   verbs:
   - get
   - list
@@ -38,9 +41,56 @@ rules:
   - list
   - watch
 - apiGroups:
-  - admissionregistration.k8s.io
+  - "admissionregistration.k8s.io"
   resources:
   - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterrolebindings
+  - roles
+  - clusterroles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - gatewayclasses
+  - gateways
+  - httproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "networking.istio.io"
+  resources:
+  - virtualservices
   verbs:
   - get
   - list

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -183,6 +183,15 @@
                             "default": "true"
                         }
                     }
+                },
+                "resourceConfigMap": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": "true"
+                        }
+                    }
                 }
             }
         },

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -94,6 +94,13 @@ clusterVisibility:
     # snapshot has been taken. Any resources deleted when KAC does not watch the Kubernetes
     # cluster will not be shown as deleted in the Falcon UI.
     enabled: true
+  # KAC watches configmaps by default. It tries to redact sensitive information by doing
+  # regex pattern matching for known sensitive patterns, before sending the events to
+  # CrowdStrike cloud.
+  resourceConfigMap:
+    # If set to false, KAC does not watch the ConfigMap events, and you will not be able to
+    # see the latest state of the configmaps.
+    enabled: true
 
 # Falcon KAC can usually discover the clusterName automatically so setting clusterName here is normally
 # not necessary, but in some cases the clusterName cannot be discovered by the KAC, e.g. for self-hosted


### PR DESCRIPTION
The PR contains a couple of changes:
- New resource permissions added in `clusterrole.yaml` to support KAC's extended visibility.
- A new parameter to support disabling visibility on the `configmaps`.