### PR TITLE
Add env variable for POD_NODE_NAME to daemonset falcon-node-sensor container

### DIFF
--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -174,6 +174,11 @@ spec:
         {{- if (eq .Values.node.backend "bpf") }}
         {{- include "falcon-sensor.daemonsetResources" . | nindent 8 }}
         {{- end }}
+        env:
+          - name: POD_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         envFrom:
         - configMapRef:
             name: {{ include "falcon-sensor.configMapName" . }}


### PR DESCRIPTION
The env variable is populated from spec.nodeName in the falcon-node-sensor container.