### PR TITLE
feat: add extra volumes and mounts, make automount sa token configurable

### DIFF
--- a/helm-charts/falcon-sensor/templates/_helpers.tpl
+++ b/helm-charts/falcon-sensor/templates/_helpers.tpl
@@ -284,3 +284,22 @@ Get sidecar container registry config json from global value if it exists
 {{- .Values.container.image.pullSecrets.registryConfigJSON | default "" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Extra volume mounts for falcon-sensor container
+*/}}
+{{- define "falcon-sensor.extraVolumeMounts" -}}
+{{- if .Values.container.extraVolumeMounts }}
+{{- toYaml .Values.container.extraVolumeMounts }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Extra volumes for falcon-sensor container
+*/}}
+{{- define "falcon-sensor.extraVolumes" -}}
+{{- if .Values.container.extraVolumes }}
+{{- toYaml .Values.container.extraVolumes }}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -184,11 +184,14 @@ spec:
         volumeMounts:
           - name: falconstore
             mountPath: /opt/CrowdStrike/falconstore
+        {{- include "falcon-sensor.extraVolumeMounts" . | nindent 10 }}
       volumes:
         - name: falconstore
           hostPath:
             path: /opt/CrowdStrike/falconstore
+        {{- include "falcon-sensor.extraVolumes" . | nindent 8 }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
     {{- if or .Values.node.daemonset.priorityClassName .Values.node.gke.autopilot }}
       priorityClassName: {{ include "falcon-sensor.priorityClassName" . }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -295,6 +295,12 @@
                 "enabled"
             ],
             "properties": {
+                "extraVolumeMounts": {
+                  "type": "array"
+                },
+                "extraVolumes": {
+                  "type": "array"
+                },
                 "tolerations": {
                     "type": "array"
                 },
@@ -497,6 +503,10 @@
                             "iam.gke.io/gcp-service-account": "my-service-account@my-project.iam.gserviceaccount.com"
                         }
                     ]
+                },
+                "automountServiceAccountToken": {
+                  "type": "boolean",
+                  "default": "false"
                 }
             }
         },

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -260,9 +260,15 @@ container:
       cpu: 10m
       memory: 20Mi
 
+  # Additional volume mounts in falcon sensor container
+  extraVolumeMounts: []
+  # Additional volumes in falcon-sensor pod
+  extraVolumes: []
+
 serviceAccount:
   name: crowdstrike-falcon-sa
   annotations: {}
+  automountServiceAccountToken: true
 
 # Deploys the test suite during install for testing purposes.
 testing:


### PR DESCRIPTION
It's common that automountServiceAccountToken is enforced to false in enterprize clusters (token is mounted via [projected volume](https://kubernetes.io/docs/concepts/storage/projected-volumes/#serviceaccounttoken)). This PR makes it possible to set serviceAccount.automountServiceAccountToken to false, as well as adds extraVolumes and extraVolumeMounts to make pod/container more flexible for such a use case.