### PR TITLE
Remove duplicate app.kubernetes.io/name label

### DIFF
--- a/helm-charts/falcon-image-analyzer/templates/_helpers.tpl
+++ b/helm-charts/falcon-image-analyzer/templates/_helpers.tpl
@@ -73,7 +73,6 @@ Common labels
 */}}
 {{- define "falcon-image-analyzer.labels" -}}
 app.kubernetes.io/component: iar
-app.kubernetes.io/name: {{ include "falcon-image-analyzer.name" . }}
 crowdstrike.com/provider: crowdstrike
 helm.sh/chart: {{ include "falcon-image-analyzer.chart" . }}
 {{ include "falcon-image-analyzer.selectorLabels" . }}


### PR DESCRIPTION
The `app.kubernetes.io/name` label was added to the common labels even though they include the selector labels which in turn already have a `app.kubernetes.io/name` label.