### PR TITLE
allow minimum tls verison of 1.2 to be specified

### DIFF
--- a/helm-charts/falcon-kac/templates/configmap.yaml
+++ b/helm-charts/falcon-kac/templates/configmap.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "falcon-kac.labels" . | nindent 4 }}
 data:
   __CS_ADMISSION_CONTROL_ENABLED: {{ .Values.admissionControl.enabled | quote }}
+  {{- if .Values.tlsVersionMinimum }}
+  __CS_TLS_PROTOCOL_MIN: {{ .Values.tlsVersionMinimum }}
+  {{- end }}
   {{- include "falcon-kac.generateWatcherEnvVars" . | nindent 2 }}
   {{- if not (include "falcon-kac.falconSecretEnabled" . | eq "true") }}
   FALCONCTL_OPT_CID: {{ include "falcon-kac.falconCid" . }}

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -69,6 +69,13 @@
             "default": "3650",
             "minimum": 0
         },
+        "tlsVersionMinimum": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "pattern": "^(TLS1.2|TLS1.3)$"
+        },
         "domainName": {
             "type": [
                 "null",


### PR DESCRIPTION
Allow minimum TLS protocol version 1.2. for KAC to be specified. The default is 1.3