### PR TITLE
feat: add extra objects to support secret related operators

### DIFF
--- a/helm-charts/falcon-sensor/Chart.yaml
+++ b/helm-charts/falcon-sensor/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.34.1
+version: 1.35.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.34.1
+appVersion: 1.35.0
 
 keywords:
   - CrowdStrike

--- a/helm-charts/falcon-sensor/templates/daemonset.yaml
+++ b/helm-charts/falcon-sensor/templates/daemonset.yaml
@@ -137,6 +137,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+        {{- if .Values.node.extraInitVolumeMounts }}
+        volumeMounts:
+        {{- with .Values.node.extraInitVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
       containers:
       - name: falcon-node-sensor
         image: "{{ include "falcon-sensor.image" . }}"
@@ -189,10 +195,16 @@ spec:
         volumeMounts:
           - name: falconstore
             mountPath: /opt/CrowdStrike/falconstore
+        {{- with .Values.node.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
         - name: falconstore
           hostPath:
             path: /opt/CrowdStrike/falconstore
+      {{- with .Values.node.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriod }}
     {{- if or .Values.node.daemonset.priorityClassName .Values.node.gke.autopilot }}

--- a/helm-charts/falcon-sensor/templates/extra-objects.yaml
+++ b/helm-charts/falcon-sensor/templates/extra-objects.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraObjects }}
+{{- range $index, $object := .Values.extraObjects }}
+---
+{{- tpl (toYaml $object) $ }}
+{{- end }}
+{{- end }}

--- a/helm-charts/falcon-sensor/values.schema.json
+++ b/helm-charts/falcon-sensor/values.schema.json
@@ -273,6 +273,15 @@
                     "default": "60",
                     "pattern": "^[0-9]+$"
                 },
+                "extraVolumes": {
+                    "type": "array"
+                },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
+                "extraInitVolumeMounts": {
+                    "type": "array"
+                },
                 "hooks": {
                     "type": "object",
                     "properties": {
@@ -481,6 +490,9 @@
                     }
                 }
             }
+        },
+        "extraObjects": {
+            "type": "array"
         },
         "serviceAccount": {
             "type": "object",

--- a/helm-charts/falcon-sensor/values.yaml
+++ b/helm-charts/falcon-sensor/values.yaml
@@ -103,6 +103,11 @@ node:
   # How long to wait for Falcon pods to stop gracefully
   terminationGracePeriod: 60
 
+  # Extra volumes and mounts for the daemonset (e.g., CSI SecretProviderClass mounts)
+  extraVolumes: []
+  extraVolumeMounts: []
+  extraInitVolumeMounts: []
+
   hooks:
     # Settings for the node post-delete helm hook
     postDelete:
@@ -259,6 +264,9 @@ container:
     requests:
       cpu: 10m
       memory: 20Mi
+
+# Render arbitrary Kubernetes manifests (e.g., SecretProviderClass, ExternalSecret)
+extraObjects: []
 
 serviceAccount:
   name: crowdstrike-falcon-sa


### PR DESCRIPTION
## Summary

- Add `extraObjects` rendering plus `node.extraVolumes`, `node.extraVolumeMounts`, and `node.extraInitVolumeMounts` in falcon-sensor to support secret-related operators (e.g., SecretProviderClass/ExternalSecret).

Related : #414 