### PR TITLE
Update values.yaml to remove latest from tag

### DIFF
--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -15,7 +15,7 @@ image:
 
   # Overrides the image tag. In general, tags should not be used (including semver tags or `latest`). This variable is provided for those
   # who have yet to move off of using tags. The sha256 digest should be used in place of tags for increased security and image immutability.
-  tag: latest
+  tag:
   # Setting a digest will override any tag and should be used instead of tags.
   #
   # Example digest variable configuration:


### PR DESCRIPTION
When there is an helm install executed, the docker checks for the image with latest tag and fails. thelatest version of KAC only consists of only the following two tags 
 "7.33.0-3105",
     "7.34.0-3201"