### PR TITLE
Add custom pod labels to falcon image analyzer

### DIFF
--- a/helm-charts/falcon-image-analyzer/templates/daemonset.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/daemonset.yaml
@@ -55,7 +55,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
-    {{- include "falcon-image-analyzer.labels" . | nindent 8 }}
+        {{- include "falcon-image-analyzer.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if or $imagePullSecret $registryConfigJson (.Values.crowdstrikeConfig.dockerAPIToken) }}
       imagePullSecrets:

--- a/helm-charts/falcon-image-analyzer/templates/deployment.yaml
+++ b/helm-charts/falcon-image-analyzer/templates/deployment.yaml
@@ -56,7 +56,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
-    {{- include "falcon-image-analyzer.labels" . | nindent 8 }}
+        {{- include "falcon-image-analyzer.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if or $imagePullSecret $registryConfigJson (.Values.crowdstrikeConfig.dockerAPIToken) }}
       imagePullSecrets:

--- a/helm-charts/falcon-image-analyzer/values.yaml
+++ b/helm-charts/falcon-image-analyzer/values.yaml
@@ -54,6 +54,8 @@ volumeMounts:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
 
 securityContext: {}


### PR DESCRIPTION
Add the ability to add custom pod labels to the falcon image analyzer so can use features like [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels) in Azure.