### PR TITLE
feat(falcon-kac): make priorityClassName configurable

### DIFF
--- a/helm-charts/falcon-kac/README.md
+++ b/helm-charts/falcon-kac/README.md
@@ -219,4 +219,5 @@ The following tables lists the Falcon KAC configurable parameters and their defa
 | `falconSecret.enabled`                         | Enable k8s secrets to inject sensitive Falcon values                                                                               | false      (Must be true if falcon.cid is not set)            |
 | `falconSecret.secretName`                      | Existing k8s secret name to inject sensitive Falcon values.<br> The secret must be under the same namespace as the KAC deployment. | None       (Existing secret must include `FALCONCTL_OPT_CID`) |
 | `clusterName`                                  | Manually set cluster name for self-hosted Kubernetes clusters where auto-discovery fails (e.g., MicroK8s). Displayed as hostname in Host Management UI. | None (auto-discovery used) |
+| `priorityClassName`                            | Set the priorityClassName for the KAC pods to protect them from eviction under resource pressure.        | `system-cluster-critical`                                     |
 | `falconImageAnalyzerNamespace`                 | Falcon Image Analyzer namespace | falcon-image-analyzer |

--- a/helm-charts/falcon-kac/templates/deployment_webhook.yaml
+++ b/helm-charts/falcon-kac/templates/deployment_webhook.yaml
@@ -300,7 +300,7 @@ spec:
           name: crowdstrike-falcon-vol2
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: system-cluster-critical
+      priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/helm-charts/falcon-kac/templates/resourcequota.yaml
+++ b/helm-charts/falcon-kac/templates/resourcequota.yaml
@@ -13,4 +13,4 @@ spec:
     - operator: In
       scopeName: PriorityClass
       values:
-      - system-cluster-critical
+      - {{ .Values.priorityClassName }}

--- a/helm-charts/falcon-kac/values.schema.json
+++ b/helm-charts/falcon-kac/values.schema.json
@@ -427,6 +427,10 @@
         "falconImageAnalyzerNamespace": {
             "type": "string",
             "default": "falcon-image-analyzer"
+        },
+        "priorityClassName": {
+            "type": "string",
+            "default": "system-cluster-critical"
         }
     }
 }

--- a/helm-charts/falcon-kac/values.yaml
+++ b/helm-charts/falcon-kac/values.yaml
@@ -127,6 +127,10 @@ labels: {}
 # Annotations to apply to the webhook deployment
 podAnnotations: {}
 
+# Set the priorityClassName for the KAC deployment.
+# A priority class is required to protect KAC pods from eviction under resource pressure.
+priorityClassName: system-cluster-critical
+
 tolerations: []
 
 affinity:


### PR DESCRIPTION
## Change Description
The KAC Deployment and ResourceQuota have `system-cluster-critical` hardcoded as the `priorityClassName`. Some environments enforce policies  (e.g. via Kyverno) that restrict usage of `system-*` priority classes,  preventing KAC from being deployed.  
  
This change makes `priorityClassName` configurable via `values.yaml` while keeping `system-cluster-critical` as the default to preserve existing behavior.