### PR TITLE
Correct falcon sensor 1.9.0 helm chart URL

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3136,10 +3136,10 @@ entries:
     version: 1.9.1
   - apiVersion: v2
     appVersion: 1.9.0
-    created: "2022-03-11T19:05:03.966959859Z"
+    created: "2022-03-11T17:17:29.565327093Z"
     description: A Helm chart to deploy CrowdStrike Falcon sensors into Kubernetes
       clusters.
-    digest: 5d99d00832339f0ae06b556fccb6c8ba2dbcdde5cc68bf2a9f6ddf0ede2f5ead
+    digest: 33aadb36917fc3998218f7ca850e9d380a1643b6467e1f75bbaf3d32c11bc30f
     home: https://crowdstrike.com
     icon: https://raw.githubusercontent.com/CrowdStrike/falcon-helm/main/images/crowdstrike-logo.svg
     keywords:
@@ -3159,7 +3159,7 @@ entries:
     - https://github.com/CrowdStrike/falcon-helm
     type: application
     urls:
-    - https://github.com/CrowdStrike/falcon-helm/releases/download/1.9.1/falcon-sensor-1.9.0.tgz
+    - https://github.com/CrowdStrike/falcon-helm/releases/download/1.9.0/falcon-sensor-1.9.0.tgz
     version: 1.9.0
   - apiVersion: v2
     appVersion: 1.8.0


### PR DESCRIPTION
Please see github issue #507 for details.

### TLDR

The URL for falcon sensor 1.9.0 helm chart is incorrect in the `index.yaml` file, which is currently returning 404

https://github.com/CrowdStrike/falcon-helm/blob/fa81091d58d562e0c4795c31c8681d0123889655/index.yaml#L3162

### Proposed changes

Manually revert commit c2fcc4bc77443f92d422928dc69e9524c8de8c62, which introduce the incorrect URL.

closes: https://github.com/CrowdStrike/falcon-helm/issues/507