### PR TITLE
feat: includes optional serviceaccount for job-controller sts

### DIFF
--- a/helm-charts/falcon-self-hosted-registry-assessment/templates/job-controller-deployment.yaml
+++ b/helm-charts/falcon-self-hosted-registry-assessment/templates/job-controller-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/job-controller-configmap.yaml") . | sha256sum }}
     spec:
+      {{ if .Values.jobController.serviceAccount.create }}
+      serviceAccountName: {{ include "ra-self-hosted-job-controller.fullname" . }}
+      {{- end }}
       securityContext:
 {{ if .Values.jobController.podSecurityContext -}}
 {{ .Values.jobController.podSecurityContext | toYaml | indent 8 }}

--- a/helm-charts/falcon-self-hosted-registry-assessment/templates/job-controller-service-account.yaml
+++ b/helm-charts/falcon-self-hosted-registry-assessment/templates/job-controller-service-account.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.jobController.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ra-self-hosted-job-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "ra-self-hosted-job-controller.labels" . | nindent 4 }}
+{{- end }}

--- a/helm-charts/falcon-self-hosted-registry-assessment/values.yaml
+++ b/helm-charts/falcon-self-hosted-registry-assessment/values.yaml
@@ -138,6 +138,8 @@ executor:
 #      optional: false
 
 jobController:
+  serviceAccount:
+    create: false # true also deploys a Service Account for the job controller if it's required to have one by restrictions like Openshift Container Platform's Security Context Constraints
   storageEngine: "sqlite"  # sqlite or memory
   image:
     registry:


### PR DESCRIPTION
Adds optional ServiceAccount support for the job-controller StatefulSet.
This is disabled by default to preserve existing behavior, and allows users in environments like OpenShift to create or specify a ServiceAccount when required.